### PR TITLE
Detect the method and URL arguments more reliably

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use std::str::FromStr;
 
 use regex::Regex;
@@ -94,39 +95,54 @@ pub struct Cli {
     pub default_scheme: Option<String>,
 
     /// The request URL, preceded by an optional HTTP method.
-    #[structopt(name = "[METHOD] URL", parse(try_from_str = parse_method_url))]
-    pub method_url: (Option<Method>, String),
+    #[structopt(name = "[METHOD] URL")]
+    raw_method_or_url: String,
 
     /// Optional key-value pairs to be included in the request.
     #[structopt(name = "REQUEST_ITEM")]
+    raw_rest_args: Vec<String>,
+
+    /// The HTTP method, if supplied.
+    #[structopt(skip)]
+    pub method: Option<Method>,
+
+    /// The request URL.
+    #[structopt(skip)]
+    pub url: String,
+
+    /// Optional key-value pairs to be included in the request.
+    #[structopt(skip)]
     pub request_items: Vec<RequestItem>,
 }
 
 impl Cli {
-    pub fn from_args() -> Self {
+    pub fn from_args() -> Result<Self> {
         Cli::from_iter(std::env::args())
     }
 
-    pub fn from_iter(iter: impl IntoIterator<Item = String>) -> Self {
-        let mut args = vec![];
-        let mut method = None;
-        // Merge `method` and `url` entries from std::env::args()
-        for arg in iter {
-            if arg.parse::<Method>().is_ok() {
-                method = Some(arg)
-            } else if let Some(method_value) = method {
-                args.push(format!("{} {}", method_value, arg));
-                method = None;
-            } else {
-                args.push(arg);
+    pub fn from_iter(iter: impl IntoIterator<Item = String>) -> Result<Self> {
+        let mut cli: Self = StructOpt::from_iter(iter);
+        let mut rest_args = mem::take(&mut cli.raw_rest_args).into_iter();
+        match cli.raw_method_or_url.parse::<Method>() {
+            Ok(method) => {
+                cli.method = Some(method);
+                cli.url = rest_args.next().ok_or_else(|| {
+                    Error::with_description("Missing URL", ErrorKind::MissingRequiredArgument)
+                })?;
+            }
+            Err(_) => {
+                cli.method = None;
+                cli.url = mem::take(&mut cli.raw_method_or_url);
             }
         }
-
-        StructOpt::from_iter(args)
+        for request_item in rest_args {
+            cli.request_items.push(request_item.parse()?);
+        }
+        Ok(cli)
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Method {
     GET,
     HEAD,
@@ -176,15 +192,6 @@ impl From<&Option<Body>> for Method {
             Some(_) => Method::POST,
             None => Method::GET,
         }
-    }
-}
-
-fn parse_method_url(s: &str) -> Result<(Option<Method>, String)> {
-    let parts = s.split_whitespace().collect::<Vec<_>>();
-    if parts.len() == 1 {
-        Ok((None, parts[0].to_string()))
-    } else {
-        Ok((Some(parts[0].parse()?), parts[1].to_string()))
     }
 }
 
@@ -314,7 +321,7 @@ impl FromStr for Print {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RequestItem {
     HttpHeader(String, String),
     HttpHeaderToUnset(String),
@@ -369,10 +376,92 @@ impl FromStr for RequestItem {
                 _ => unreachable!(),
             }
         } else {
+            // TODO: We can also end up here if the method couldn't be parsed
+            // and was interpreted as a URL, making the actual URL a request
+            // item
             Err(Error::with_description(
-                &format!("{:?} is not a valid value", request_item),
+                &format!("{:?} is not a valid request item", request_item),
                 ErrorKind::InvalidValue,
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<Cli> {
+        Cli::from_iter(
+            Some("xh".to_string())
+                .into_iter()
+                .chain(args.iter().map(|s| s.to_string())),
+        )
+    }
+
+    #[test]
+    fn implicit_method() {
+        let cli = parse(&["example.org"]).unwrap();
+        assert_eq!(cli.method, None);
+        assert_eq!(cli.url, "example.org");
+        assert!(cli.request_items.is_empty());
+    }
+
+    #[test]
+    fn explicit_method() {
+        let cli = parse(&["get", "example.org"]).unwrap();
+        assert_eq!(cli.method, Some(Method::GET));
+        assert_eq!(cli.url, "example.org");
+        assert!(cli.request_items.is_empty());
+    }
+
+    #[test]
+    fn missing_url() {
+        parse(&["get"]).unwrap_err();
+    }
+
+    #[test]
+    fn space_in_url() {
+        let cli = parse(&["post", "example.org/foo bar"]).unwrap();
+        assert_eq!(cli.method, Some(Method::POST));
+        assert_eq!(cli.url, "example.org/foo bar");
+        assert!(cli.request_items.is_empty());
+    }
+
+    #[test]
+    fn request_items() {
+        let cli = parse(&["get", "example.org", "foo=bar"]).unwrap();
+        assert_eq!(cli.method, Some(Method::GET));
+        assert_eq!(cli.url, "example.org");
+        assert_eq!(
+            cli.request_items,
+            vec![RequestItem::DataField("foo".to_string(), "bar".to_string())]
+        );
+    }
+
+    #[test]
+    fn request_items_implicit_method() {
+        let cli = parse(&["example.org", "foo=bar"]).unwrap();
+        assert_eq!(cli.method, None);
+        assert_eq!(cli.url, "example.org");
+        assert_eq!(
+            cli.request_items,
+            vec![RequestItem::DataField("foo".to_string(), "bar".to_string())]
+        );
+    }
+
+    #[test]
+    fn superfluous_arg() {
+        parse(&["get", "example.org", "foobar"]).unwrap_err();
+    }
+
+    #[test]
+    fn superfluous_arg_implicit_method() {
+        parse(&["example.org", "foobar"]).unwrap_err();
+    }
+
+    #[test]
+    fn multiple_methods() {
+        parse(&["get", "post", "example.org"]).unwrap_err();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn get_user_agent() -> &'static str {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Cli::from_args();
+    let args = Cli::from_args()?;
 
     let request_items = RequestItems::new(args.request_items);
     let query = request_items.query();
@@ -59,10 +59,9 @@ async fn main() -> Result<()> {
         (None, None) => None,
     };
 
-    let (method, url) = args.method_url;
-    let url = Url::new(url, args.default_scheme)?;
+    let url = Url::new(args.url, args.default_scheme)?;
     let host = url.host().ok_or_else(|| anyhow!("Missing hostname"))?;
-    let method = method.unwrap_or_else(|| Method::from(&body)).into();
+    let method = args.method.unwrap_or_else(|| Method::from(&body)).into();
     let auth = Auth::new(args.auth, args.auth_type, &host)?;
     let redirect = match args.follow || args.download {
         true => Policy::limited(args.max_redirects.unwrap_or(10)),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -238,7 +238,7 @@ mod test {
     use assert_matches::assert_matches;
 
     fn run_cmd(args: impl IntoIterator<Item = String>, is_stdout_tty: bool) -> Printer {
-        let args = Cli::from_iter(args);
+        let args = Cli::from_iter(args).unwrap();
         let buffer = Buffer::new(args.download, &args.output, is_stdout_tty).unwrap();
         Printer::new(args.pretty, args.theme, false, buffer)
     }


### PR DESCRIPTION
Determining whether the HTTP method is explicit or implicit is tricky. I've changed it from pre-processing `structopt`'s input to post-processing its output, which is a bit more robust.

Resolves #54.