### PR TITLE
Improve automatically generated download filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime2ext"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2ec500bafee2f3f91550a5a256bfca76451ad909f1a91fa5380275890f1c5"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mime_guess"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1107,9 @@ name = "serde"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1654,6 +1667,7 @@ dependencies = [
  "indoc",
  "jsonxf",
  "lazy_static",
+ "mime2ext",
  "predicates",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ atty = "0.2"
 jsonxf = "1.0"
 indicatif = "0.15.0"
 lazy_static = "1.4.0"
+mime2ext = "0.1.0"
 regex = "1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "json", "gzip", "brotli", "multipart"] }
 rpassword = "5.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,14 @@ async fn main() -> Result<()> {
         printer.print_request_body(&request)?;
     }
     if !args.offline {
+        let orig_url = request.url().clone();
         let response = client.execute(request).await?;
         if print.response_headers {
             printer.print_response_headers(&response)?;
         }
         if args.download {
             let resume = response.status() == StatusCode::PARTIAL_CONTENT;
-            download_file(response, args.output, resume, args.quiet).await?;
+            download_file(response, args.output, &orig_url, resume, args.quiet).await?;
         } else if print.response_body {
             printer.print_response_body(response).await?;
         }


### PR DESCRIPTION
- Parse some non-conforming Content-Disposition headers
- Ignore trailing slashes when generating from URL
- Generate from the original URL instead of the URL after redirects
- If there's no extension, pick one using the MIME type