### PR TITLE
Fix --continue, add --check-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ FLAGS:
 
 OPTIONS:
     -A, --auth-type <auth-type>              Specify the auth mechanism [possible values: Basic, Bearer]
-    -a, --auth <USER[:PASS]>                 Authenticate as USER. PASS will be prompted if missing
+    -a, --auth <USER[:PASS] | TOKEN>
     -o, --output <output>                    Save output to FILE instead of stdout
         --max-redirects <max-redirects>      Number of redirects to follow, only respected if `follow` is set
     -p, --print <print>                      String specifying what the output should contain

--- a/README.md
+++ b/README.md
@@ -35,19 +35,20 @@ FLAGS:
     -m, --multipart       Similar to --form, but always sends a multipart/form-data request (i.e., even without files)
     -I, --ignore-stdin    Do not attempt to read stdin
     -F, --follow          Do follow redirects
-    -d, --download
+    -d, --download        Download the body to a file instead of printing it
     -h, --headers         Print only the response headers, shortcut for --print=h
     -b, --body            Print only the response body, Shortcut for --print=b
     -c, --continue        Resume an interrupted download
     -v, --verbose         Print the whole request as well as the response
     -q, --quiet           Do not print to stdout or stderr
     -S, --stream          Always stream the response body
+        --check-status    Exit with an error status code if the server replies with an error
         --help            Prints help information
     -V, --version         Prints version information
 
 OPTIONS:
     -A, --auth-type <auth-type>              Specify the auth mechanism [possible values: Basic, Bearer]
-    -a, --auth <auth>
+    -a, --auth <USER[:PASS]>                 Authenticate as USER. PASS will be prompted if missing
     -o, --output <output>                    Save output to FILE instead of stdout
         --max-redirects <max-redirects>      Number of redirects to follow, only respected if `follow` is set
     -p, --print <print>                      String specifying what the output should contain

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,8 @@ pub struct Cli {
     #[structopt(short = "A", long = "auth-type", possible_values = &AuthType::variants(), case_insensitive = true)]
     pub auth_type: Option<AuthType>,
 
-    #[structopt(short = "a", long)]
+    /// Authenticate as USER. PASS will be prompted if missing.
+    #[structopt(short = "a", long, name = "USER[:PASS]")]
     pub auth: Option<String>,
 
     /// Save output to FILE instead of stdout.
@@ -51,6 +52,7 @@ pub struct Cli {
     #[structopt(long = "max-redirects")]
     pub max_redirects: Option<usize>,
 
+    /// Download the body to a file instead of printing it.
     #[structopt(short = "d", long)]
     pub download: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -333,16 +333,16 @@ pub enum RequestItem {
 impl FromStr for RequestItem {
     type Err = Error;
     fn from_str(request_item: &str) -> Result<RequestItem> {
-        let re1 = regex!(r"^(.+?)@(.+?);type=(.+?)$");
-        let re2 = regex!(r"^(.+?)(==|:=|=|@|:)((?s).+)$");
-        let re3 = regex!(r"^(.+?)(:|;)$");
+        regex!(FORM_FILE_TYPED = r"^(.+?)@(.+?);type=(.+?)$");
+        regex!(PARAM = r"^(.+?)(==|:=|=|@|:)((?s).+)$");
+        regex!(NO_HEADER = r"^(.+?)(:|;)$");
 
-        if let Some(caps) = re1.captures(request_item) {
+        if let Some(caps) = FORM_FILE_TYPED.captures(request_item) {
             let key = caps[1].to_string();
             let value = caps[2].to_string();
             let file_type = caps[3].to_string();
             Ok(RequestItem::FormFile(key, value, Some(file_type)))
-        } else if let Some(caps) = re2.captures(request_item) {
+        } else if let Some(caps) = PARAM.captures(request_item) {
             let key = caps[1].to_string();
             let value = caps[3].to_string();
             match &caps[2] {
@@ -361,7 +361,7 @@ impl FromStr for RequestItem {
                 "@" => Ok(RequestItem::FormFile(key, value, None)),
                 _ => unreachable!(),
             }
-        } else if let Some(caps) = re3.captures(request_item) {
+        } else if let Some(caps) = NO_HEADER.captures(request_item) {
             let key = caps[1].to_string();
             match &caps[2] {
                 ":" => Ok(RequestItem::HttpHeaderToUnset(key)),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,8 +36,7 @@ pub struct Cli {
     #[structopt(short = "A", long = "auth-type", possible_values = &AuthType::variants(), case_insensitive = true)]
     pub auth_type: Option<AuthType>,
 
-    /// Authenticate as USER. PASS will be prompted if missing.
-    #[structopt(short = "a", long, name = "USER[:PASS]")]
+    #[structopt(short = "a", long, name = "USER[:PASS] | TOKEN")]
     pub auth: Option<String>,
 
     /// Save output to FILE instead of stdout.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,6 +89,10 @@ pub struct Cli {
     #[structopt(short = "s", long = "style", possible_values = &Theme::variants(), case_insensitive = true)]
     pub theme: Option<Theme>,
 
+    /// Exit with an error status code if the server replies with an error.
+    #[structopt(long)]
+    pub check_status: bool,
+
     /// The default scheme to use if not specified in the URL.
     #[structopt(long = "default-scheme")]
     pub default_scheme: Option<String>,

--- a/src/download.rs
+++ b/src/download.rs
@@ -92,7 +92,7 @@ fn open_new_file(file_name: String) -> io::Result<(String, File)> {
     panic!("Could not create file after unreasonable number of attempts");
 }
 
-// https://github.com/httpie/httpie/blob/e944dbd7fa/httpie/downloads.py#L44
+// https://github.com/httpie/httpie/blob/84c7327057/httpie/downloads.py#L44
 // https://tools.ietf.org/html/rfc7233#section-4.2
 fn total_for_content_range(header: &str, expected_start: u64) -> Result<u64> {
     regex!(RE_RANGE =

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,10 +1,9 @@
 use std::fs::{self, File, OpenOptions};
-use std::io;
+use std::io::{self, ErrorKind};
 
 use anyhow::{anyhow, Context, Result};
 use atty::Stream;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
-use io::ErrorKind;
 use mime2ext::mime2ext;
 use reqwest::header::{
     HeaderMap, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,12 +1,16 @@
-use std::fs::{self, OpenOptions};
-use std::io::Write as IoWrite;
+use std::fs::{self, File, OpenOptions};
+use std::io;
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use atty::Stream;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
+use io::ErrorKind;
 use mime2ext::mime2ext;
-use reqwest::header::{HeaderMap, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::header::{
+    HeaderMap, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,
+};
 use reqwest::Response;
+use reqwest::StatusCode;
 
 use crate::regex;
 
@@ -59,31 +63,88 @@ fn get_file_name(response: &Response, orig_url: &reqwest::Url) -> String {
     filename
 }
 
-pub fn get_file_size(path: &Option<String>) -> Option<u64> {
-    match path {
-        Some(path) => Some(std::fs::metadata(path).ok()?.len()),
-        _ => None,
-    }
-}
-
-fn exists(file_name: &str) -> bool {
-    fs::metadata(&file_name).is_ok()
+pub fn get_file_size(path: Option<&str>) -> Option<u64> {
+    Some(fs::metadata(path?).ok()?.len())
 }
 
 /// Find a file name that doesn't exist yet.
-fn generate_file_name(file_name: String) -> String {
-    if !exists(&file_name) {
-        return file_name;
-    }
-    let mut suffix: u32 = 1;
-    loop {
-        let candidate = format!("{}-{}", file_name, suffix);
-        if !exists(&candidate) {
-            return candidate;
+fn open_new_file(file_name: String) -> io::Result<(String, File)> {
+    fn try_open_new(file_name: &str) -> io::Result<Option<File>> {
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&file_name)
+        {
+            Ok(file) => Ok(Some(file)),
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => Ok(None),
+            Err(err) => Err(err),
         }
-        suffix += 1;
     }
+    if let Some(file) = try_open_new(&file_name)? {
+        return Ok((file_name, file));
+    }
+    for suffix in 1..u32::MAX {
+        let candidate = format!("{}-{}", file_name, suffix);
+        if let Some(file) = try_open_new(&candidate)? {
+            return Ok((candidate, file));
+        }
+    }
+    panic!("Could not create file after unreasonable number of attempts");
 }
+
+// https://github.com/httpie/httpie/blob/e944dbd7fa/httpie/downloads.py#L44
+// https://tools.ietf.org/html/rfc7233#section-4.2
+fn total_for_content_range(header: &str, expected_start: u64) -> Result<u64> {
+    regex!(RE_RANGE =
+        r"^bytes (?P<first_byte_pos>\d+)-(?P<last_byte_pos>\d+)"
+        r"/(?:\*|(?P<complete_length>\d+))$"
+    );
+    let caps = RE_RANGE
+        .captures(header)
+        // Could happen if header uses unit other than bytes
+        .ok_or_else(|| anyhow!("Can't parse Content-Range header, can't resume download"))?;
+    let first_byte_pos: u64 = caps
+        .name("first_byte_pos")
+        .unwrap()
+        .as_str()
+        .parse()
+        .context("Can't parse Content-Range first_byte_pos")?;
+    let last_byte_pos: u64 = caps
+        .name("last_byte_pos")
+        .unwrap()
+        .as_str()
+        .parse()
+        .context("Can't parse Content-Range last_byte_pos")?;
+    let complete_length: Option<u64> = caps
+        .name("complete_length")
+        .map(|num| {
+            num.as_str()
+                .parse()
+                .context("Can't parse Content-Range complete_length")
+        })
+        .transpose()?;
+    // Note that last_byte_pos must be strictly less than complete_length
+    // If first_byte_pos == last_byte_pos exactly one byte is sent
+    if first_byte_pos > last_byte_pos {
+        return Err(anyhow!("Invalid Content-Range: {:?}", header));
+    }
+    if let Some(complete_length) = complete_length {
+        if last_byte_pos >= complete_length {
+            return Err(anyhow!("Invalid Content-Range: {:?}", header));
+        }
+        if complete_length != last_byte_pos + 1 {
+            return Err(anyhow!("Content-Range has wrong end: {:?}", header));
+        }
+    }
+    if expected_start != first_byte_pos {
+        return Err(anyhow!("Content-Range has wrong start: {:?}", header));
+    }
+    Ok(last_byte_pos + 1)
+}
+
+const BAR_TEMPLATE: &str =
+    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes} {bytes_per_sec} ETA {eta}";
+const SPINNER_TEMPLATE: &str = "{spinner:.green} [{elapsed_precise}] {bytes} {bytes_per_sec} {msg}";
 
 pub async fn download_file(
     mut response: reqwest::Response,
@@ -92,69 +153,74 @@ pub async fn download_file(
     // original URL, before redirects. That's less surprising and matches
     // HTTPie. Hence this argument.
     orig_url: &reqwest::Url,
-    resume: bool,
+    mut resume: Option<u64>,
     quiet: bool,
 ) -> Result<()> {
-    let (mut buffer, dest_name): (Box<dyn IoWrite>, String) = match file_name {
-        Some(file_name) => (
-            Box::new(
-                OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .append(resume)
-                    .open(&file_name)?,
-            ),
-            file_name,
-        ),
-        None if atty::is(Stream::Stdout) => {
-            let file_name = get_file_name(&response, &orig_url);
-            // TODO: do not avoid name conflict if `continue` flag is specified
-            let file_name = generate_file_name(file_name);
-            (
-                Box::new(
-                    OpenOptions::new()
-                        .write(true)
-                        .create(true)
-                        .append(resume)
-                        .open(&file_name)?,
-                ),
-                file_name,
-            )
+    if resume.is_some() && response.status() != StatusCode::PARTIAL_CONTENT {
+        resume = None;
+    }
+
+    let mut buffer: Box<dyn io::Write>;
+    let dest_name: String;
+
+    if let Some(file_name) = file_name {
+        let mut open_opts = OpenOptions::new();
+        open_opts.write(true).create(true);
+        if resume.is_some() {
+            open_opts.append(true);
+        } else {
+            open_opts.truncate(true);
         }
-        None => (Box::new(std::io::stdout()), "stdout".into()),
-    };
+
+        dest_name = file_name;
+        buffer = Box::new(open_opts.open(&dest_name)?);
+    } else if atty::is(Stream::Stdout) {
+        let (new_name, handle) = open_new_file(get_file_name(&response, &orig_url))?;
+        dest_name = new_name;
+        buffer = Box::new(handle);
+    } else {
+        dest_name = "<stdout>".into();
+        buffer = Box::new(io::stdout());
+    }
+
+    let starting_length: u64;
+    let total_length: Option<u64>;
+    if let Some(resume) = resume {
+        let header = response
+            .headers()
+            .get(CONTENT_RANGE)
+            .ok_or_else(|| anyhow!("Missing Content-Range header"))?
+            .to_str()
+            .map_err(|_| anyhow!("Bad Content-Range header"))?;
+        starting_length = resume;
+        total_length = Some(total_for_content_range(header, starting_length)?);
+    } else {
+        starting_length = 0;
+        total_length = get_content_length(&response.headers());
+    }
 
     let pb = if quiet {
         None
+    } else if let Some(total_length) = total_length {
+        eprintln!(
+            "Downloading {} to {:?}",
+            HumanBytes(total_length - starting_length),
+            dest_name
+        );
+        let style = ProgressStyle::default_bar()
+            .template(BAR_TEMPLATE)
+            .progress_chars("#>-");
+        Some(ProgressBar::new(total_length).with_style(style))
     } else {
-        match get_content_length(&response.headers()) {
-            Some(content_length) => {
-                eprintln!(
-                    "Downloading {} to \"{}\"",
-                    HumanBytes(content_length),
-                    dest_name
-                );
-                let template = "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes} {bytes_per_sec} ETA {eta}";
-                Some(
-                    ProgressBar::new(content_length).with_style(
-                        ProgressStyle::default_bar()
-                            .template(template)
-                            .progress_chars("#>-"),
-                    ),
-                )
-            }
-            None => {
-                eprintln!("Downloading to \"{}\"", dest_name);
-                Some(
-                    ProgressBar::new_spinner().with_style(ProgressStyle::default_bar().template(
-                        "{spinner:.green} [{elapsed_precise}] {bytes} {bytes_per_sec} {msg}",
-                    )),
-                )
-            }
-        }
+        eprintln!("Downloading to {:?}", dest_name);
+        let style = ProgressStyle::default_bar().template(SPINNER_TEMPLATE);
+        Some(ProgressBar::new_spinner().with_style(style))
     };
+    if let Some(pb) = &pb {
+        pb.set_position(starting_length);
+    }
 
-    let mut downloaded = 0;
+    let mut downloaded = starting_length;
     while let Some(chunk) = response.chunk().await? {
         buffer.write_all(&chunk)?;
         downloaded += chunk.len() as u64;
@@ -168,4 +234,25 @@ pub async fn download_file(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_range_parsing() {
+        let expected = vec![
+            (2, "bytes 2-5/6", Some(6)),
+            (2, "bytes 2-5/*", Some(6)),
+            (5, "bytes 5-5/6", Some(6)),
+            (2, "bytes 3-5/6", None),
+            (2, "bytes 1-5/6", None),
+            (2, "bytes 2-4/6", None),
+            (2, "bytes 2-6/6", None),
+        ];
+        for (start, header, result) in expected {
+            assert_eq!(total_for_content_range(header, start).ok(), result);
+        }
+    }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -19,14 +19,14 @@ fn get_content_length(headers: &HeaderMap) -> Option<u64> {
 
 fn get_file_name(response: &Response, orig_url: &reqwest::Url) -> String {
     fn from_header(response: &Response) -> Option<String> {
-        let quoted = regex!("filename=\"([^\"]*)\"");
+        regex!(QUOTED = "filename=\"([^\"]*)\"");
         // Against the spec, but used by e.g. Github's zip downloads
-        let unquoted = regex!("filename=([^;=\"]*)");
+        regex!(UNQUOTED = "filename=([^;=\"]*)");
 
         let header = response.headers().get(CONTENT_DISPOSITION)?.to_str().ok()?;
-        let caps = quoted
+        let caps = QUOTED
             .captures(header)
-            .or_else(|| unquoted.captures(header))?;
+            .or_else(|| UNQUOTED.captures(header))?;
         Some(caps[1].to_string())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,17 @@ fn get_user_agent() -> &'static str {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    std::process::exit(inner_main().await?);
+}
+
+/// [`main`] is wrapped around this function so it can safely exit with an
+/// exit code.
+///
+/// [`std::process::exit`] is a hard termination, that ends the process
+/// without doing any cleanup. So we need to return from this function first.
+///
+/// The outer main function could also be a good place for error handling.
+async fn inner_main() -> Result<i32> {
     let args = Cli::from_args()?;
 
     let request_items = RequestItems::new(args.request_items);
@@ -141,12 +152,23 @@ async fn main() -> Result<()> {
         if print.response_headers {
             printer.print_response_headers(&response)?;
         }
+        let status = response.status();
+        let exit_code: i32 = match status.as_u16() {
+            _ if !(args.check_status || args.download) => 0,
+            300..=399 if !args.follow => 3,
+            400..=499 => 4,
+            500..=599 => 5,
+            _ => 0,
+        };
         if args.download {
             let resume = response.status() == StatusCode::PARTIAL_CONTENT;
             download_file(response, args.output, &orig_url, resume, args.quiet).await?;
         } else if print.response_body {
             printer.print_response_body(response).await?;
         }
+        // TODO: print warning if output is being redirected
+        Ok(exit_code)
+    } else {
+        Ok(0)
     }
-    Ok(())
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -149,12 +149,7 @@ impl Printer {
         let status = response.status();
         let headers = response.headers();
 
-        let status_line = format!(
-            "{:?} {} {}\n",
-            version,
-            status.as_str(),
-            status.canonical_reason().unwrap_or("Unknown Status Code")
-        );
+        let status_line = format!("{:?} {}\n", version, status);
         let headers = self.headers_to_string(headers, self.sort_headers);
 
         self.print_headers(&(status_line + &headers))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,9 +173,14 @@ macro_rules! vec_of_strings {
 
 #[macro_export]
 macro_rules! regex {
-    ($re:expr) => {{
+    ($name:ident = $($re:expr)+) => {
         lazy_static::lazy_static! {
-            static ref RE: regex::Regex = regex::Regex::new($re).unwrap();
+            static ref $name: regex::Regex = regex::Regex::new(concat!($($re,)+)).unwrap();
+        }
+    };
+    ($($re:expr)+) => {{
+        lazy_static::lazy_static! {
+            static ref RE: regex::Regex = regex::Regex::new(concat!($($re,)+)).unwrap();
         }
         &RE
     }};

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,7 +10,7 @@ fn get_command() -> Command {
 }
 
 #[test]
-fn basic_post() -> Result<(), Box<dyn std::error::Error>> {
+fn basic_post() {
     let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--offline")
@@ -35,12 +35,10 @@ fn basic_post() -> Result<(), Box<dyn std::error::Error>> {
         }
 
     "#});
-
-    Ok(())
 }
 
 #[test]
-fn basic_get() -> Result<(), Box<dyn std::error::Error>> {
+fn basic_get() {
     let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--offline")
@@ -58,12 +56,10 @@ fn basic_get() -> Result<(), Box<dyn std::error::Error>> {
         user-agent: xh/0.0.0 (test mode)
 
     "#});
-
-    Ok(())
 }
 
 #[test]
-fn basic_head() -> Result<(), Box<dyn std::error::Error>> {
+fn basic_head() {
     let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--offline")
@@ -81,12 +77,10 @@ fn basic_head() -> Result<(), Box<dyn std::error::Error>> {
         user-agent: xh/0.0.0 (test mode)
 
     "#});
-
-    Ok(())
 }
 
 #[test]
-fn basic_options() -> Result<(), Box<dyn std::error::Error>> {
+fn basic_options() {
     let mut cmd = get_command();
     cmd.arg("-v")
         .arg("--ignore-stdin")
@@ -98,8 +92,6 @@ fn basic_options() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert()
         .stdout(predicate::str::contains("HTTP/1.1 200 OK"));
     cmd.assert().stdout(predicate::str::contains("allow:"));
-
-    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
- `--continue` now works for resuming downloads. It was incomplete before.
- `--check-status` is supported, and is automatically active for downloads (so you don't download error pages).
- `--auth` and `--download` are now documented.

Internal work:
- Improved regex macro (#58)
- Fixed Clippy warnings