### PR TITLE
Support the --proxy option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1014,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "url",
  "wasm-bindgen",
@@ -1253,6 +1260,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1343,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ jsonxf = "1.0"
 indicatif = "0.15.0"
 lazy_static = "1.4.0"
 regex = "1"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "json", "gzip", "brotli", "multipart"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream", "json", "gzip", "brotli", "multipart", "socks"] }
 rpassword = "5.0.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -58,19 +58,22 @@ FLAGS:
     -V, --version         Prints version information
 
 OPTIONS:
-    -A, --auth-type <auth-type>                Specify the auth mechanism [possible values: Basic, Bearer]
-    -a, --auth <USER[:PASS] | TOKEN>
-    -o, --output <output>                      Save output to FILE instead of stdout
-        --max-redirects <max-redirects>        Number of redirects to follow, only respected if `follow` is set
-    -p, --print <print>                        String specifying what the output should contain
-        --pretty <pretty>                      Controls output processing [possible values: All, Colors, Format, None]
-    -s, --style <theme>                        Output coloring style [possible values: Auto, Solarized]
-        --proxy <<PROTOCOL>:<PROXY_URL>>...    Proxy to use for a specific protocol. The value passed to this option
-                                               should take the form of <PROTOCOL>:<PROXY_URL>. You can specify proxies
-                                               for multiple protocols by repeating this option. Note that when this
-                                               option is absent, the environment variables `http_proxy` and
-                                               `https_proxy` can be used to set proxies to use
-        --default-scheme <default-scheme>      The default scheme to use if not specified in the URL
+    -A, --auth-type <auth-type>              Specify the auth mechanism [possible values: Basic, Bearer]
+    -a, --auth <USER[:PASS] | TOKEN>         
+    -o, --output <output>                    Save output to FILE instead of stdout
+        --max-redirects <max-redirects>      Number of redirects to follow, only respected if `follow` is set
+    -p, --print <print>                      String specifying what the output should contain
+        --pretty <pretty>                    Controls output processing [possible values: All, Colors, Format, None]
+    -s, --style <theme>                      Output coloring style [possible values: Auto, Solarized]
+        --proxy <PROTOCOL:PROXY_URL>...      Proxy to use for a specific protocol. The value passed to this option
+                                             should take the form of <PROTOCOL>:<PROXY_URL>. You can specify proxies for
+                                             multiple protocols by repeating this option. For example, if you want to
+                                             use a HTTP proxy for HTTPS URLs: `--proxy https:http://proxy.host:8080`. If
+                                             your proxy requires credentials, put them in the URL, like so: `--proxy
+                                             http:socks5://user:password@proxy.host:8000`. Note that when this option is
+                                             absent, the environment variables `http_proxy` and `https_proxy` can be
+                                             used to set proxies to use
+        --default-scheme <default-scheme>    The default scheme to use if not specified in the URL
 
 ARGS:
     <[METHOD] URL>       The request URL, preceded by an optional HTTP method

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ cargo install xh
 ## Usage
 ```
 xh 0.7.0
+
 USAGE:
-    xh [FLAGS] [OPTIONS] <[METHOD] URL> [REQUEST_ITEM]...
+    xh [FLAGS] [OPTIONS] <[METHOD] URL> [--] [REQUEST_ITEM]...
 
 FLAGS:
         --offline         Construct HTTP requests without sending them anywhere
@@ -45,7 +46,7 @@ FLAGS:
     -m, --multipart       Similar to --form, but always sends a multipart/form-data request (i.e., even without files)
     -I, --ignore-stdin    Do not attempt to read stdin
     -F, --follow          Do follow redirects
-    -d, --download
+    -d, --download        
     -h, --headers         Print only the response headers, shortcut for --print=h
     -b, --body            Print only the response body, Shortcut for --print=b
     -c, --continue        Resume an interrupted download
@@ -56,14 +57,19 @@ FLAGS:
     -V, --version         Prints version information
 
 OPTIONS:
-    -A, --auth-type <auth-type>              Specify the auth mechanism [possible values: Basic, Bearer]
-    -a, --auth <auth>
-    -o, --output <output>                    Save output to FILE instead of stdout
-        --max-redirects <max-redirects>      Number of redirects to follow, only respected if `follow` is set
-    -p, --print <print>                      String specifying what the output should contain
-        --pretty <pretty>                    Controls output processing [possible values: All, Colors, Format, None]
-    -s, --style <theme>                      Output coloring style [possible values: Auto, Solarized]
-        --default-scheme <default-scheme>    The default scheme to use if not specified in the URL
+    -A, --auth-type <auth-type>                Specify the auth mechanism [possible values: Basic, Bearer]
+    -a, --auth <auth>                          
+    -o, --output <output>                      Save output to FILE instead of stdout
+        --max-redirects <max-redirects>        Number of redirects to follow, only respected if `follow` is set
+    -p, --print <print>                        String specifying what the output should contain
+        --pretty <pretty>                      Controls output processing [possible values: All, Colors, Format, None]
+    -s, --style <theme>                        Output coloring style [possible values: Auto, Solarized]
+        --proxy <<PROTOCOL>:<PROXY_URL>>...    Proxy to use for a specific protocol. The value passed to this option
+                                               should take the form of <PROTOCOL>:<PROXY_URL>. You can specify proxies
+                                               for multiple protocols by repeating this option. Note that when this
+                                               option is absent, the environment variables `http_proxy` and
+                                               `https_proxy` can be used to set proxies to use
+        --default-scheme <default-scheme>      The default scheme to use if not specified in the URL
 
 ARGS:
     <[METHOD] URL>       The request URL, preceded by an optional HTTP method

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,7 +95,7 @@ pub struct Cli {
     /// <PROTOCOL>:<PROXY_URL>. You can specify proxies for multiple protocols by repeating this option.
     /// Note that when this option is absent, the environment variables `http_proxy` and
     /// `https_proxy` can be used to set proxies to use.
-    #[structopt(long, value_name = "<PROTOCOL>:<PROXY_URL>", number_of_values = 1)]
+    #[structopt(long, value_name = "PROTOCOL:PROXY_URL", number_of_values = 1)]
     pub proxy: Option<Vec<Proxy>>,
 
     /// The default scheme to use if not specified in the URL.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,13 +97,18 @@ pub struct Cli {
     #[structopt(long)]
     pub check_status: bool,
 
-    /// Proxy to use for a specific protocol. The value passed to this option should take the form of
-    /// <PROTOCOL>:<PROXY_URL>. You can specify proxies for multiple protocols by repeating this option.
-    /// For example, if you want to use a HTTP proxy for HTTPS URLs: `--proxy
-    /// https:http://proxy.host:8080`. If your proxy requires credentials, put them in the URL,
-    /// like so: `--proxy http:socks5://user:password@proxy.host:8000`.
-    /// Note that when this option is absent, the environment variables `http_proxy` and
-    /// `https_proxy` can be used to set proxies to use.
+    /// Proxy to use for a specific protocol. The value passed to this option should take the form
+    /// of <PROTOCOL>:<PROXY_URL>. For example: `--proxy https:http://proxy.host:8080`.
+    ///
+    /// PROTOCOL can be `http`, `https` or `all`.
+    ///
+    /// If your proxy requires credentials, put them in the URL, like so: `--proxy
+    /// http:socks5://user:password@proxy.host:8000`.
+    ///
+    /// You can specify proxies for multiple protocols by repeating this option.
+    ///
+    /// When omitting this option, the environment variables `http_proxy` and `https_proxy` can
+    /// also be used.
     #[structopt(long, value_name = "PROTOCOL:PROXY_URL", number_of_values = 1)]
     pub proxy: Vec<Proxy>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -340,7 +340,7 @@ impl FromStr for Proxy {
                 let url = reqwest::Url::try_from(url).map_err(|e| {
                     Error::with_description(
                         &format!(
-                            "Invalid proxy URL '{}' for protocol {}: {}",
+                            "Invalid proxy URL '{}' for protocol '{}': {}",
                             url, protocol, e
                         ),
                         ErrorKind::InvalidValue,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,7 +105,7 @@ pub struct Cli {
     /// Note that when this option is absent, the environment variables `http_proxy` and
     /// `https_proxy` can be used to set proxies to use.
     #[structopt(long, value_name = "PROTOCOL:PROXY_URL", number_of_values = 1)]
-    pub proxy: Option<Vec<Proxy>>,
+    pub proxy: Vec<Proxy>,
 
     /// The default scheme to use if not specified in the URL.
     #[structopt(long = "default-scheme")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,6 +93,9 @@ pub struct Cli {
 
     /// Proxy to use for a specific protocol. The value passed to this option should take the form of
     /// <PROTOCOL>:<PROXY_URL>. You can specify proxies for multiple protocols by repeating this option.
+    /// For example, if you want to use a HTTP proxy for HTTPS URLs: `--proxy
+    /// https:http://proxy.host:8080`. If your proxy requires credentials, put them in the URL,
+    /// like so: `--proxy http:socks5://user:password@proxy.host:8000`.
     /// Note that when this option is absent, the environment variables `http_proxy` and
     /// `https_proxy` can be used to set proxies to use.
     #[structopt(long, value_name = "PROTOCOL:PROXY_URL", number_of_values = 1)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,14 +80,12 @@ async fn inner_main() -> Result<i32> {
     let mut client = Client::builder().redirect(redirect);
     let mut resume: Option<u64> = None;
 
-    if let Some(proxies) = args.proxy {
-        for proxy in proxies {
-            client = client.proxy(match proxy {
-                Proxy::Http(url) => reqwest::Proxy::http(url),
-                Proxy::Https(url) => reqwest::Proxy::https(url),
-                Proxy::All(url) => reqwest::Proxy::all(url),
-            }?);
-        }
+    for proxy in args.proxy {
+        client = client.proxy(match proxy {
+            Proxy::Http(url) => reqwest::Proxy::http(url),
+            Proxy::Https(url) => reqwest::Proxy::https(url),
+            Proxy::All(url) => reqwest::Proxy::all(url),
+        }?);
     }
 
     let client = client.build()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ async fn inner_main() -> Result<i32> {
     let mut client = Client::builder().redirect(redirect);
     let mut resume: Option<u64> = None;
 
-    for proxy in args.proxy {
+    for proxy in args.proxy.into_iter().rev() {
         client = client.proxy(match proxy {
             Proxy::Http(url) => reqwest::Proxy::http(url),
             Proxy::Https(url) => reqwest::Proxy::https(url),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -128,3 +128,47 @@ fn multiline_value() {
 
     "#});
 }
+
+#[test]
+fn proxy_invalid_protocol() {
+    let mut cmd = get_command();
+    cmd.arg("--offline")
+        .arg("--pretty=format")
+        .arg("--proxy=invalid:http://127.0.0.1:8000")
+        .arg("GET")
+        .arg("http://httpbin.org/get");
+
+    cmd.assert().stderr(indoc! {r#"
+        error: Invalid value for '--proxy <<PROTOCOL>:<PROXY_URL>>...': error: Unknown protocol to set a proxy for: invalid
+
+    "#});
+}
+
+#[test]
+fn proxy_invalid_proxy_url() {
+    let mut cmd = get_command();
+    cmd.arg("--offline")
+        .arg("--pretty=format")
+        .arg("--proxy=invalid:127.0.0.1:8000")
+        .arg("GET")
+        .arg("http://httpbin.org/get");
+
+    cmd.assert().stderr(indoc! {r#"
+        error: Invalid value for '--proxy <<PROTOCOL>:<PROXY_URL>>...': error: Invalid proxy URL '127.0.0.1:8000' for protocol 'invalid': relative URL without a base
+
+    "#});
+}
+
+#[test]
+fn proxy_multiple_valid_proxies() {
+    let mut cmd = get_command();
+    cmd.arg("--offline")
+        .arg("--pretty=format")
+        .arg("--proxy=http:https://127.0.0.1:8000")
+        .arg("--proxy=https:socks5://127.0.0.1:8000")
+        .arg("--proxy=all:http://127.0.0.1:8000")
+        .arg("GET")
+        .arg("http://httpbin.org/get");
+
+    cmd.assert().success();
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -139,7 +139,7 @@ fn proxy_invalid_protocol() {
         .arg("http://httpbin.org/get");
 
     cmd.assert().stderr(indoc! {r#"
-        error: Invalid value for '--proxy <<PROTOCOL>:<PROXY_URL>>...': error: Unknown protocol to set a proxy for: invalid
+        error: Invalid value for '--proxy <PROTOCOL:PROXY_URL>...': error: Unknown protocol to set a proxy for: invalid
 
     "#});
 }
@@ -154,7 +154,7 @@ fn proxy_invalid_proxy_url() {
         .arg("http://httpbin.org/get");
 
     cmd.assert().stderr(indoc! {r#"
-        error: Invalid value for '--proxy <<PROTOCOL>:<PROXY_URL>>...': error: Invalid proxy URL '127.0.0.1:8000' for protocol 'invalid': relative URL without a base
+        error: Invalid value for '--proxy <PROTOCOL:PROXY_URL>...': error: Invalid proxy URL '127.0.0.1:8000' for protocol 'invalid': relative URL without a base
 
     "#});
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -204,34 +204,100 @@ fn download() {
     assert_eq!(read_to_string(&outfile).unwrap(), "file contents\n");
 }
 
-#[test]
-fn proxy_invalid_protocol() {
+fn get_proxy_command(
+    protocol_to_request: &str,
+    protocol_to_proxy: &str,
+    proxy_url: &str,
+) -> Command {
     let mut cmd = get_command();
-    cmd.arg("--offline")
-        .arg("--pretty=format")
-        .arg("--proxy=invalid:http://127.0.0.1:8000")
+    cmd.arg("--pretty=format")
+        .arg("--check-status")
+        .arg(format!("--proxy={}:{}", protocol_to_proxy, proxy_url))
         .arg("GET")
-        .arg("http://httpbin.org/get");
-
-    cmd.assert().stderr(indoc! {r#"
-        error: Invalid value for '--proxy <PROTOCOL:PROXY_URL>...': error: Unknown protocol to set a proxy for: invalid
-
-    "#});
+        .arg(format!("{}://example.test/get", protocol_to_request));
+    cmd
 }
 
 #[test]
-fn proxy_invalid_proxy_url() {
+fn proxy_http_proxy() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(GET).header("host", "example.test");
+        then.status(200);
+    });
+
+    get_proxy_command("http", "http", &server.base_url())
+        .assert()
+        .success();
+
+    mock.assert();
+}
+
+#[test]
+fn proxy_https_proxy() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(CONNECT);
+        then.status(502);
+    });
+
+    get_proxy_command("https", "https", &server.base_url())
+        .assert()
+        .stderr(predicate::str::contains("unsuccessful tunnel"))
+        .failure();
+
+    mock.assert();
+}
+
+#[test]
+fn proxy_all_proxy() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(CONNECT);
+        then.status(502);
+    });
+
+    get_proxy_command("https", "all", &server.base_url())
+        .assert()
+        .stderr(predicate::str::contains("unsuccessful tunnel"))
+        .failure();
+    mock.assert();
+
+    get_proxy_command("http", "all", &server.base_url())
+        .assert()
+        .failure();
+
+    mock.assert();
+}
+
+#[test]
+fn last_supplied_proxy_wins() {
+    let first_server = MockServer::start();
+    let first_mock = first_server.mock(|when, then| {
+        when.method(GET).header("host", "example.test");
+        then.status(500);
+    });
+    let second_server = MockServer::start();
+    let second_mock = second_server.mock(|when, then| {
+        when.method(GET).header("host", "example.test");
+        then.status(200);
+    });
+
     let mut cmd = get_command();
-    cmd.arg("--offline")
-        .arg("--pretty=format")
-        .arg("--proxy=invalid:127.0.0.1:8000")
-        .arg("GET")
-        .arg("http://httpbin.org/get");
+    cmd.args(&[
+        format!("--proxy=http:{}", first_server.base_url()).as_str(),
+        format!("--proxy=http:{}", second_server.base_url()).as_str(),
+        "GET",
+        "http://example.test",
+    ])
+    .assert()
+    .success();
 
-    cmd.assert().stderr(indoc! {r#"
-        error: Invalid value for '--proxy <PROTOCOL:PROXY_URL>...': error: Invalid proxy URL '127.0.0.1:8000' for protocol 'invalid': relative URL without a base
-
-    "#});
+    first_mock.assert_hits(0);
+    second_mock.assert();
 }
 
 #[test]


### PR DESCRIPTION
The reqwest crate does all the heavy lifting (including using the
http_proxy and https_proxy environment variables when the --proxy option
isn't present).
As noted, it's possible to use different proxies for different
protocols.

The "socks" configuration for the reqwest crate was enabled to allow
users to use a socks proxy.