### PR TITLE
CLI-related improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,6 +2615,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rpassword",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "shell-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ pem = "0.8.2"
 regex = "1"
 reqwest = { version = "0.11.1", default-features = false, features = ["rustls-tls", "json", "gzip", "brotli", "multipart", "blocking", "socks"] }
 rpassword = "5.0.0"
+serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7.0"
 shell-escape = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ FLAGS:
         --check-status    Exit with an error status code if the server replies with an error
         --curl            Print a translation to a `curl` command
         --curl-long       Use the long versions of curl's flags
+        --https           Make HTTPS requests if not specified in the URL
         --help            Prints help information
     -V, --version         Prints version information
 
@@ -67,7 +68,6 @@ OPTIONS:
         --pretty <STYLE>             Controls output processing [possible values: all, colors, format, none]
     -s, --style <THEME>              Output coloring style [possible values: auto, solarized]
         --proxy <PROTOCOL:URL>...    Use a proxy for a protocol. For example: `--proxy https:http://proxy.host:8080`
-        --default-scheme <SCHEME>    The default scheme to use if not specified in the URL
         --verify <VERIFY>            If "no", skip SSL verification. If a file path, use it as a CA bundle
         --cert <FILE>                Use a client side certificate for SSL
         --cert-key <FILE>            A private key file to use with --cert

--- a/doc/man-template.roff
+++ b/doc/man-template.roff
@@ -9,7 +9,7 @@ Optional. If omitted, a GET or a POST will be done depending on whether the requ
 .HP
 URL
 .IP
-The URL to request. The scheme defaults to 'http://' unless \fB\-\-default\-scheme\fR is used.
+The URL to request. The scheme defaults to 'http://' unless \fB\-\-https\fR is used.
 .IP
 A leading colon works as shorthand for localhost. :8000 is equivalent to localhost:8000, and :/path is equivalent to localhost/path.
 .HP

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -20,7 +20,7 @@ Optional. If omitted, a GET or a POST will be done depending on whether the requ
 .HP
 URL
 .IP
-The URL to request. The scheme defaults to 'http://' unless \fB\-\-default\-scheme\fR is used.
+The URL to request. The scheme defaults to 'http://' unless \fB\-\-https\fR is used.
 .IP
 A leading colon works as shorthand for localhost. :8000 is equivalent to localhost:8000, and :/path is equivalent to localhost/path.
 .HP
@@ -116,6 +116,10 @@ For translating the other way, try https://curl2httpie.online/.
 .IP
 Use the long versions of curl's flags
 .HP
+\fB\-\-https\fR
+.IP
+Make HTTPS requests if not specified in the URL
+.HP
 \fB\-\-help\fR
 .IP
 Prints help information
@@ -171,10 +175,6 @@ You can specify proxies for multiple protocols by repeating this option.
 .IP
 The environment variables `http_proxy` and `https_proxy` can also be used, but are completely ignored if
 \fB\-\-proxy\fR is passed.
-.HP
-\fB\-\-default\-scheme\fR <SCHEME>
-.IP
-The default scheme to use if not specified in the URL
 .HP
 \fB\-\-verify\fR <VERIFY>
 .IP

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,7 +389,12 @@ impl From<&Buffer> for Pretty {
         if test_pretend_term() {
             Pretty::format
         } else if b.is_terminal() {
-            Pretty::all
+            if env::var_os("NO_COLOR").is_some() {
+                // https://no-color.org/
+                Pretty::format
+            } else {
+                Pretty::all
+            }
         } else {
             Pretty::none
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -305,7 +305,7 @@ impl Cli {
         }
 
         if matches!(
-            app.get_bin_name(),
+            app.get_bin_name().and_then(|name| name.split('.').next()),
             Some("https") | Some("xhs") | Some("xhttps")
         ) {
             cli.https = true;
@@ -783,6 +783,12 @@ mod tests {
     #[test]
     fn executable_name() {
         let args = Cli::from_iter_safe(&["xhs", "example.org"]).unwrap();
+        assert_eq!(args.https, true);
+    }
+
+    #[test]
+    fn executable_name_extension() {
+        let args = Cli::from_iter_safe(&["xhs.exe", "example.org"]).unwrap();
         assert_eq!(args.https, true);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -144,8 +144,12 @@ pub struct Cli {
     pub proxy: Vec<Proxy>,
 
     /// The default scheme to use if not specified in the URL.
-    #[structopt(long = "default-scheme", value_name = "SCHEME")]
+    #[structopt(long = "default-scheme", value_name = "SCHEME", hidden = true)]
     pub default_scheme: Option<String>,
+
+    /// Make HTTPS requests if not specified in the URL.
+    #[structopt(long = "https")]
+    pub https: bool,
 
     /// The request URL, preceded by an optional HTTP method.
     ///
@@ -312,6 +316,9 @@ impl Cli {
         }
         if self.curl_long {
             self.curl = true;
+        }
+        if self.https {
+            self.default_scheme = Some("https".to_string());
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,13 @@ use reqwest::header::{
     HeaderValue, ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_TYPE, RANGE, USER_AGENT,
 };
 use reqwest::redirect::Policy;
-use reqwest::Method;
 
 use crate::auth::parse_auth;
 use crate::buffer::Buffer;
-use crate::cli::{Cli, Pretty, Print, Proxy, Theme, Verify};
+use crate::cli::{Cli, Pretty, Print, Proxy, RequestType, Theme, Verify};
 use crate::download::{download_file, get_file_size};
 use crate::printer::Printer;
-use crate::request_items::{Body, RequestItems};
+use crate::request_items::{Body, RequestItems, FORM_CONTENT_TYPE, JSON_ACCEPT, JSON_CONTENT_TYPE};
 use crate::url::construct_url;
 use crate::utils::{test_mode, test_pretend_term};
 
@@ -65,27 +64,19 @@ fn inner_main() -> Result<i32> {
     let url = construct_url(&args.url, args.default_scheme.as_deref(), query)?;
 
     let ignore_stdin = args.ignore_stdin || atty::is(Stream::Stdin) || test_pretend_term();
-    let body = match request_items.body(args.form, args.multipart)? {
-        Some(_) if !ignore_stdin => {
+    let mut body = request_items.body(args.request_type)?;
+    if !ignore_stdin {
+        if !body.is_empty() {
             return Err(anyhow!(
                 "Request body (from stdin) and Request data (key=value) cannot be mixed"
             ));
         }
-        None if !ignore_stdin => {
-            let mut buffer = Vec::new();
-            stdin().read_to_end(&mut buffer)?;
-            Some(Body::Raw(buffer))
-        }
-        body => body,
-    };
+        let mut buffer = Vec::new();
+        stdin().read_to_end(&mut buffer)?;
+        body = Body::Raw(buffer);
+    }
 
-    let method = args.method.unwrap_or_else(|| {
-        if body.is_some() {
-            Method::POST
-        } else {
-            Method::GET
-        }
-    });
+    let method = args.method.unwrap_or_else(|| body.pick_method());
     let redirect = match args.follow {
         true => Policy::limited(args.max_redirects.unwrap_or(10)),
         false => Policy::none(),
@@ -161,20 +152,35 @@ fn inner_main() -> Result<i32> {
             .header(USER_AGENT, get_user_agent());
 
         request_builder = match body {
-            Some(Body::Form(body)) => request_builder
-                .header(ACCEPT, HeaderValue::from_static("*/*"))
-                .form(&body),
-            Some(Body::Multipart(body)) => request_builder
-                .header(ACCEPT, HeaderValue::from_static("*/*"))
-                .multipart(body),
-            Some(Body::Json(body)) => request_builder
-                .header(ACCEPT, HeaderValue::from_static("application/json, */*"))
-                .json(&body),
-            Some(Body::Raw(body)) => request_builder
-                .header(ACCEPT, HeaderValue::from_static("application/json, */*"))
-                .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
-                .body(body),
-            None => request_builder.header(ACCEPT, HeaderValue::from_static("*/*")),
+            Body::Form(body) => request_builder.form(&body),
+            Body::Multipart(body) => request_builder.multipart(body),
+            Body::Json(body) => {
+                // An empty JSON body would produce "{}" instead of "", so
+                // this is the one kind of body that needs an is_empty() check
+                if !body.is_empty() {
+                    request_builder
+                        .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
+                        .json(&body)
+                } else if args.json {
+                    request_builder
+                        .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
+                        .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE))
+                } else {
+                    // We're here because this is the default request type
+                    // There's nothing to do
+                    request_builder
+                }
+            }
+            Body::Raw(body) => match args.request_type {
+                Some(RequestType::Json) => request_builder
+                    .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
+                    .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE)),
+                Some(RequestType::Form) => request_builder
+                    .header(CONTENT_TYPE, HeaderValue::from_static(FORM_CONTENT_TYPE)),
+                Some(RequestType::Multipart) => unreachable!(),
+                None => request_builder,
+            }
+            .body(body),
         };
 
         if args.resume {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,13 @@ fn inner_main() -> Result<i32> {
     let mut body = request_items.body(args.request_type)?;
     if !ignore_stdin {
         if !body.is_empty() {
-            return Err(anyhow!(
-                "Request body (from stdin) and Request data (key=value) cannot be mixed"
-            ));
+            if body.is_multipart() {
+                return Err(anyhow!("Cannot build a multipart request body from stdin"));
+            } else {
+                return Err(anyhow!(
+                    "Request body (from stdin) and Request data (key=value) cannot be mixed"
+                ));
+            }
         }
         let mut buffer = Vec::new();
         stdin().read_to_end(&mut buffer)?;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -10,7 +10,7 @@ use reqwest::header::{
 
 use crate::{
     formatting::{get_json_formatter, Highlighter},
-    utils::{copy_largebuf, get_content_type, test_mode, ContentType},
+    utils::{copy_largebuf, get_content_type, test_mode, valid_json, ContentType},
 };
 use crate::{Buffer, Pretty, Theme};
 
@@ -108,6 +108,10 @@ impl Printer {
             Some(ContentType::Json) => self.print_json_text(body),
             Some(ContentType::Xml) => self.print_syntax_text(body, "xml"),
             Some(ContentType::Html) => self.print_syntax_text(body, "html"),
+            // In HTTPie part of this behavior is gated behind the --json flag
+            // But it does JSON formatting even without that flag, so doing
+            // this check unconditionally is fine
+            Some(ContentType::PotentialJson) if valid_json(body) => self.print_json_text(body),
             _ => self.buffer.print(body),
         }
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -4,7 +4,9 @@ use encoding_rs::{Encoding, UTF_8};
 use encoding_rs_io::DecodeReaderBytesBuilder;
 use mime::Mime;
 use reqwest::blocking::{Request, Response};
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, HOST};
+use reqwest::header::{
+    HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, HOST,
+};
 
 use crate::{
     formatting::{get_json_formatter, Highlighter},
@@ -216,6 +218,10 @@ impl Printer {
         let query_string = url.query().map_or(String::from(""), |q| ["?", q].concat());
         let version = reqwest::Version::HTTP_11;
         let mut headers = request.headers().clone();
+
+        headers
+            .entry(ACCEPT)
+            .or_insert_with(|| HeaderValue::from_static("*/*"));
 
         // See https://github.com/seanmonstar/reqwest/issues/1030
         // reqwest and hyper add certain headers, but only in the process of

--- a/src/request_items.rs
+++ b/src/request_items.rs
@@ -156,6 +156,10 @@ impl Body {
             Method::POST
         }
     }
+
+    pub fn is_multipart(&self) -> bool {
+        matches!(self, Body::Multipart(..))
+    }
 }
 
 impl RequestItems {

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -306,6 +306,10 @@ mod tests {
                 "curl 'https://httpbin.org/get?x=3'",
             ),
             (
+                "xhs httpbin.org/get x==3",
+                "curl 'https://httpbin.org/get?x=3'",
+            ),
+            (
                 "xh -h httpbin.org/get",
                 "curl -I -X GET 'http://httpbin.org/get'",
             ),

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -302,7 +302,7 @@ mod tests {
                 "curl -X PUT 'http://httpbin.org/put'",
             ),
             (
-                "xh --default-scheme https httpbin.org/get x==3",
+                "xh --https httpbin.org/get x==3",
                 "curl 'https://httpbin.org/get?x=3'",
             ),
             (

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,7 @@ pub enum ContentType {
     Xml,
     UrlencodedForm,
     Multipart,
+    PotentialJson,
 }
 
 pub fn get_content_type(headers: &HeaderMap) -> Option<ContentType> {
@@ -41,6 +42,10 @@ pub fn get_content_type(headers: &HeaderMap) -> Option<ContentType> {
                 Some(ContentType::Multipart)
             } else if content_type.contains("x-www-form-urlencoded") {
                 Some(ContentType::UrlencodedForm)
+            } else if content_type.contains("javascript") || content_type.contains("text") {
+                // https://github.com/httpie/httpie/blob/a32ad344dd/httpie/output/formatters/json.py#L14
+                // HTTPie additionally checks for "json", but we already bucket that into ContentType::Json
+                Some(ContentType::PotentialJson)
             } else {
                 None
             }
@@ -93,4 +98,8 @@ pub fn copy_largebuf(reader: &mut impl io::Read, writer: &mut impl Write) -> io:
             Err(e) => return Err(e),
         }
     }
+}
+
+pub fn valid_json(text: &str) -> bool {
+    serde_json::from_str::<serde::de::IgnoredAny>(text).is_ok()
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -766,7 +766,7 @@ fn inferred_nonjson_output() {
 fn noninferred_json_output() {
     let server = MockServer::start();
     let mock = server.mock(|_when, then| {
-        // Trailing comma makes it invalid JSON, though formatting would still work
+        // Valid JSON, but not declared as text
         then.header("content-type", "application/octet-stream")
             .body(r#"{"":0}"#);
     });

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -779,3 +779,33 @@ fn noninferred_json_output() {
         "#});
     mock.assert();
 }
+
+#[test]
+fn mixed_stdin_request_items() {
+    let input_file = tempfile().unwrap();
+    redirecting_command()
+        .arg("--offline")
+        .arg(":")
+        .arg("x=3")
+        .stdin(input_file)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Request body (from stdin) and Request data (key=value) cannot be mixed",
+        ));
+}
+
+#[test]
+fn multipart_stdin() {
+    let input_file = tempfile().unwrap();
+    redirecting_command()
+        .arg("--offline")
+        .arg("--multipart")
+        .arg(":")
+        .stdin(input_file)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Cannot build a multipart request body from stdin",
+        ));
+}


### PR DESCRIPTION
- Replace `--default-scheme` by `--https`. `--default-scheme` is still kept as an undocumented flag. (#72)
- If `xh` is invoked as `xhs`, `https`, or `xhttps`, run as if `--https` was used. That matches HTTPie's `https` command.
  Currently undocumented, we should figure out if we want this and if it should be part of the packaging.
  HTTPie installs both a `http` and `https` executable if you get it with `pip`, but they're just thin wrappers. I expect Cargo only lets you compile two whole separate executables, which would be a bit costly for a convenience feature.
- Bring back `--auth-type` as a hidden flag. If we add more auth types we can document it again.
- Support `NO_COLOR` environment variable to turn colors off by default (https://no-color.org/).
- Make `--json`/`--form`/`--multipart` override each other and force content-type. If you use multiple of those flags, all but the last will be ignored. And if you use them without request items the appropriate headers will still be set. This brings behavior in line with HTTPie.
- Try to detect undeclared JSON response bodies: If the response is javascript or plain text, check if it's JSON.