### PR TITLE
Adapt to_curl tests to Windows

### DIFF
--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -70,14 +70,13 @@ impl Command {
 impl std::fmt::Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let escape = if f.alternate() {
-            // If formatted with `{:#}`, force Windows (cmd.exe) formatting (for testing)
+            // If formatted with `{:#}`, use cmd.exe-style formatting
+            // This is currently not exposed
             shell_escape::windows::escape
-        } else if cfg!(test) {
-            // When testing, default to Unix for consistency
-            shell_escape::unix::escape
         } else {
-            // Otherwise use the platform default
-            shell_escape::escape
+            // By default, use Unix-style formatting regardless of platform
+            // This is also more suitable for Powershell
+            shell_escape::unix::escape
         };
         for (key, value) in &self.env {
             // This is wrong for Windows, but there doesn't seem to be a


### PR DESCRIPTION
This solves a problem with #75.

I'd like to get the input of Windows users on this. The escaping seems designed for cmd.exe, not Powershell, so it could be better to default to Unix-style escaping even on Windows. (But that can also be addressed at a later date.)