### PR TITLE
Use static OpenSSL for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,22 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.job.os }}
-    strategy: 
+    strategy:
       matrix:
         job:
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu }
-          - { os: macos-latest   , target: x86_64-apple-darwin }
-          - { os: windows-latest , target: x86_64-pc-windows-msvc }
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            use-cross: true
+          - target: arm-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            use-cross: true
+            flags: --no-default-features # Integration tests don't work with cross
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -25,29 +35,9 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --target ${{ matrix.job.target }}
-  
-  build-on-arm-and-musl:
-    name: Build on ARM and MUSL
-    runs-on: ${{ matrix.job.os }}
-    strategy: 
-      matrix:
-        job:
-          - { os: ubuntu-latest , target: arm-unknown-linux-gnueabihf }
-          - { os: ubuntu-latest , target: x86_64-unknown-linux-musl }
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.45.0 # minimum supported rust version
-          target: ${{ matrix.job.target }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
+          args: --target ${{ matrix.job.target }} ${{ matrix.job.flags }}
 
   fmt-and-clippy:
     name: Rustfmt and clippy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,22 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.job.os }}
-    strategy: 
+    strategy:
       matrix:
         job:
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu }
-          - { os: macos-latest   , target: x86_64-apple-darwin }
-          - { os: windows-latest , target: x86_64-pc-windows-msvc }
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            use-cross: true
+          - target: arm-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            use-cross: true
+            flags: --no-default-features # Integration tests don't work with cross
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -24,35 +34,15 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          use-cross: ${{ matrix.job.use-cross }}
           command: test
-          args: --target ${{ matrix.job.target }}
-  
-  build-on-arm-and-musl:
-    name: Build on ARM and MUSL
-    runs-on: ${{ matrix.job.os }}
-    strategy: 
-      matrix:
-        job:
-          - { os: ubuntu-latest , target: arm-unknown-linux-gnueabihf }
-          - { os: ubuntu-latest , target: x86_64-unknown-linux-musl }
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.45.0 # minimum supported rust version
-          target: ${{ matrix.job.target }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
+          args: --target ${{ matrix.job.target }} ${{ matrix.job.flags }}
 
   deploy:
     name: Deploy
-    needs: [ build-on-arm-and-musl, test ]
+    needs: [ test ]
     runs-on: ${{ matrix.job.os }}
-    strategy: 
+    strategy:
       matrix:
         job:
           - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: true }
@@ -70,7 +60,7 @@ jobs:
       - name: Package
         shell: bash
         run: |
-          cd target/${{ matrix.job.target }}/release          
+          cd target/${{ matrix.job.target }}/release
           if [ "${{ matrix.job.os }}" = "windows-latest" ]; then
             7z a ../../../xh-${{ matrix.job.target }}.zip xh.exe
           elif [ "${{ matrix.job.os }}" = "macos-latest" ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.14.0+1.1.1j"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1407,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2611,6 +2621,7 @@ dependencies = [
  "assert_cmd",
  "assert_matches",
  "atty",
+ "curl",
  "encoding_rs",
  "encoding_rs_io",
  "exit_status",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,19 @@ default-features = false
 features = ["parsing", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 
 [dev-dependencies]
+# Some are only needed for the `integration-tests` feature, but dev-dependencies can't be optional
 assert_cmd = "1.0"
 assert_matches = "1.4.0"
 indoc = "1.0"
 predicates = "1.0.7"
 httpmock = "0.5.5"
+curl = { version = "0.4.34", features = ["static-ssl"] }
 tempfile = "3.2.0"
+
+[features]
+default = ["integration-tests"]
+
+integration-tests = []
 
 [build-dependencies]
 syntect = { version = "4.4", default-features = false }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "integration-tests")]
 use std::{
     fs::read_to_string,
     io::{Seek, SeekFrom, Write},


### PR DESCRIPTION
`curl-rust` turns out to have a feature for building with a bundled statically linked OpenSSL. That solves some of the problems we had in #75.

The integration tests don't work on ARM, possibly because of some QEMU limitation. So I've gated those behind a default feature. The other tests do work.