### PR TITLE
Include docs/xh.1, README.md, etc in the release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
           if [ "${{ matrix.job.os }}" = "windows-latest" ]; then
             7z a "$staging.zip" $staging
           elif [ "${{ matrix.job.os }}" = "macos-latest" ]; then
-            zip -r "$staging.zip" $staging
+            gtar czvf "$staging.tar.gz" $staging
           else
             tar czvf "$staging.tar.gz" $staging
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,16 @@ jobs:
           command: build
           args: --release --target ${{ matrix.job.target }}
 
+      - name: Strip release binary (linux and macOS)
+        if: matrix.job.os != 'windows-latest'
+        run: |
+          if [ "${{ matrix.job.target }}" = "arm-unknown-linux-gnueabihf" ]; then
+            sudo apt-get -y install gcc-arm-linux-gnueabihf
+            arm-linux-gnueabihf-strip "target/${{ matrix.job.target }}/release/xh"
+          else
+            strip "target/${{ matrix.job.target }}/release/xh"
+          fi
+
       - id: get_version
         uses: battila7/get-version-action@v2
       - name: Package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,18 +67,32 @@ jobs:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
           args: --release --target ${{ matrix.job.target }}
+
+      - id: get_version
+        uses: battila7/get-version-action@v2
       - name: Package
         shell: bash
         run: |
-          cd target/${{ matrix.job.target }}/release          
           if [ "${{ matrix.job.os }}" = "windows-latest" ]; then
-            7z a ../../../xh-${{ matrix.job.target }}.zip xh.exe
-          elif [ "${{ matrix.job.os }}" = "macos-latest" ]; then
-            zip ../../../xh-${{ matrix.job.target }}.zip xh
+            bin="target/${{ matrix.job.target }}/release/xh.exe"
           else
-            tar czvf ../../../xh-${{ matrix.job.target }}.tar.gz xh
+            bin="target/${{ matrix.job.target }}/release/xh"
           fi
-          cd -
+          staging="xh-${{ steps.get_version.outputs.version }}-${{ matrix.job.target }}"
+
+          mkdir -p "$staging"/{doc,completions}
+          cp LICENSE README.md $bin $staging
+          cp CHANGELOG.md doc/xh.1 "$staging"/doc
+          cp completions/* "$staging"/completions
+
+          if [ "${{ matrix.job.os }}" = "windows-latest" ]; then
+            7z a "$staging.zip" $staging
+          elif [ "${{ matrix.job.os }}" = "macos-latest" ]; then
+            zip -r "$staging.zip" $staging
+          else
+            tar czvf "$staging.tar.gz" $staging
+          fi
+
       - name: Publish
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Also, strips debug symbols from the binary for Linux and macOS. Tested on a [temporary Github project](https://github.com/ducaale/git-deploy-test-1/tree/develop).

Resolves https://github.com/ducaale/xh/issues/70