### PR TITLE
Content-Type handling improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,12 +166,12 @@ fn main() -> Result<i32> {
                 }
             }
             Body::Raw(body) => match args.request_type {
-                Some(RequestType::Json) | None => request_builder
+                RequestType::Json => request_builder
                     .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
                     .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE)),
-                Some(RequestType::Form) => request_builder
+                RequestType::Form => request_builder
                     .header(CONTENT_TYPE, HeaderValue::from_static(FORM_CONTENT_TYPE)),
-                Some(RequestType::Multipart) => unreachable!(),
+                RequestType::Multipart => unreachable!(),
             }
             .body(body),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,13 +166,12 @@ fn main() -> Result<i32> {
                 }
             }
             Body::Raw(body) => match args.request_type {
-                Some(RequestType::Json) => request_builder
+                Some(RequestType::Json) | None => request_builder
                     .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
                     .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE)),
                 Some(RequestType::Form) => request_builder
                     .header(CONTENT_TYPE, HeaderValue::from_static(FORM_CONTENT_TYPE)),
                 Some(RequestType::Multipart) => unreachable!(),
-                None => request_builder,
             }
             .body(body),
         };

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -112,25 +112,19 @@ impl Printer {
         }
     }
 
-    fn print_javascript_text(&mut self, text: &str) -> io::Result<()> {
-        if valid_json(text) {
-            self.print_json_text(text, false)
-        } else {
-            self.print_syntax_text(text, "js")
-        }
-    }
-
     fn print_body_text(&mut self, content_type: Option<ContentType>, body: &str) -> io::Result<()> {
         match content_type {
             Some(ContentType::Json) => self.print_json_text(body, true),
             Some(ContentType::Xml) => self.print_syntax_text(body, "xml"),
             Some(ContentType::Html) => self.print_syntax_text(body, "html"),
             Some(ContentType::Css) => self.print_syntax_text(body, "css"),
-            Some(ContentType::JavaScript) => self.print_javascript_text(body),
             // In HTTPie part of this behavior is gated behind the --json flag
             // But it does JSON formatting even without that flag, so doing
             // this check unconditionally is fine
-            Some(ContentType::Text) if valid_json(body) => self.print_json_text(body, false),
+            Some(ContentType::Text) | Some(ContentType::JavaScript) if valid_json(body) => {
+                self.print_json_text(body, false)
+            }
+            Some(ContentType::JavaScript) => self.print_syntax_text(body, "js"),
             _ => self.buffer.print(body),
         }
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -86,11 +86,20 @@ impl Printer {
         }
     }
 
-    fn print_json_text(&mut self, text: &str) -> io::Result<()> {
+    fn print_json_text(&mut self, text: &str, check_valid: bool) -> io::Result<()> {
         if !self.indent_json {
             // We don't have to do anything specialized, so fall back to the generic version
-            self.print_syntax_text(text, "json")
-        } else if self.color {
+            return self.print_syntax_text(text, "json");
+        }
+
+        if check_valid && !valid_json(text) {
+            // JSONXF may mess up the text, e.g. by removing whitespace
+            // This is somewhat common as application/json is the default
+            // content type for requests
+            return self.print_syntax_text(text, "json");
+        }
+
+        if self.color {
             let mut buf = Vec::new();
             get_json_formatter().format_stream_unbuffered(&mut text.as_bytes(), &mut buf)?;
             // in principle, buf should already be valid UTF-8,
@@ -103,15 +112,25 @@ impl Printer {
         }
     }
 
+    fn print_javascript_text(&mut self, text: &str) -> io::Result<()> {
+        if valid_json(text) {
+            self.print_json_text(text, false)
+        } else {
+            self.print_syntax_text(text, "js")
+        }
+    }
+
     fn print_body_text(&mut self, content_type: Option<ContentType>, body: &str) -> io::Result<()> {
         match content_type {
-            Some(ContentType::Json) => self.print_json_text(body),
+            Some(ContentType::Json) => self.print_json_text(body, true),
             Some(ContentType::Xml) => self.print_syntax_text(body, "xml"),
             Some(ContentType::Html) => self.print_syntax_text(body, "html"),
+            Some(ContentType::Css) => self.print_syntax_text(body, "css"),
+            Some(ContentType::JavaScript) => self.print_javascript_text(body),
             // In HTTPie part of this behavior is gated behind the --json flag
             // But it does JSON formatting even without that flag, so doing
             // this check unconditionally is fine
-            Some(ContentType::PotentialJson) if valid_json(body) => self.print_json_text(body),
+            Some(ContentType::Text) if valid_json(body) => self.print_json_text(body, false),
             _ => self.buffer.print(body),
         }
     }
@@ -183,6 +202,9 @@ impl Printer {
             Some(ContentType::Json) => self.print_json_stream(body),
             Some(ContentType::Xml) => self.print_syntax_stream(body, "xml"),
             Some(ContentType::Html) => self.print_syntax_stream(body, "html"),
+            Some(ContentType::Css) => self.print_syntax_stream(body, "css"),
+            // print_body_text() has fancy JSON detection, but we can't do that here
+            Some(ContentType::JavaScript) => self.print_syntax_stream(body, "js"),
             _ => self.print_stream(body),
         }
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -198,7 +198,7 @@ impl Printer {
     fn headers_to_string(&self, headers: &HeaderMap, sort: bool) -> String {
         let mut headers: Vec<(&HeaderName, &HeaderValue)> = headers.iter().collect();
         if sort {
-            headers.sort_by(|(a, _), (b, _)| a.to_string().cmp(&b.to_string()))
+            headers.sort_by_key(|(name, _)| name.as_str());
         }
 
         let mut header_string = String::new();

--- a/src/request_items.rs
+++ b/src/request_items.rs
@@ -262,12 +262,12 @@ impl RequestItems {
         Ok(Body::Multipart(form))
     }
 
-    pub fn body(self, request_type: Option<RequestType>) -> Result<Body> {
+    pub fn body(self, request_type: RequestType) -> Result<Body> {
         match request_type {
-            Some(RequestType::Multipart) => self.body_as_multipart(),
-            Some(RequestType::Form) if self.has_form_files() => self.body_as_multipart(),
-            Some(RequestType::Form) => self.body_as_form(),
-            Some(RequestType::Json) | None => self.body_as_json(),
+            RequestType::Multipart => self.body_as_multipart(),
+            RequestType::Form if self.has_form_files() => self.body_as_multipart(),
+            RequestType::Form => self.body_as_form(),
+            RequestType::Json => self.body_as_json(),
         }
     }
 
@@ -276,8 +276,8 @@ impl RequestItems {
     /// It's better to use `Body::pick_method`, if possible. This method is
     /// for the benefit of `to_curl`, which sometimes has to process the
     /// request items itself.
-    pub fn pick_method(&self, request_type: Option<RequestType>) -> Method {
-        if request_type == Some(RequestType::Multipart) {
+    pub fn pick_method(&self, request_type: RequestType) -> Method {
+        if request_type == RequestType::Multipart {
             return Method::POST;
         }
         for item in &self.0 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,9 +21,11 @@ pub enum ContentType {
     Json,
     Html,
     Xml,
+    JavaScript,
+    Css,
+    Text,
     UrlencodedForm,
     Multipart,
-    PotentialJson,
 }
 
 pub fn get_content_type(headers: &HeaderMap) -> Option<ContentType> {
@@ -42,10 +44,16 @@ pub fn get_content_type(headers: &HeaderMap) -> Option<ContentType> {
                 Some(ContentType::Multipart)
             } else if content_type.contains("x-www-form-urlencoded") {
                 Some(ContentType::UrlencodedForm)
-            } else if content_type.contains("javascript") || content_type.contains("text") {
+            } else if content_type.contains("javascript") {
+                Some(ContentType::JavaScript)
+            } else if content_type.contains("css") {
+                Some(ContentType::Css)
+            } else if content_type.contains("text") {
+                // We later check if this one's JSON
+                // HTTPie checks for "json", "javascript" and "text" in one place:
                 // https://github.com/httpie/httpie/blob/a32ad344dd/httpie/output/formatters/json.py#L14
-                // HTTPie additionally checks for "json", but we already bucket that into ContentType::Json
-                Some(ContentType::PotentialJson)
+                // We have it more spread out but it behaves more or less the same
+                Some(ContentType::Text)
             } else {
                 None
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -747,6 +747,26 @@ fn inferred_json_output() {
 }
 
 #[test]
+fn inferred_json_javascript_output() {
+    let server = MockServer::start();
+    let mock = server.mock(|_when, then| {
+        then.header("content-type", "application/javascript")
+            .body(r#"{"":0}"#);
+    });
+    get_command()
+        .arg("--print=b")
+        .arg(server.base_url())
+        .assert()
+        .stdout(indoc! {r#"
+        {
+            "": 0
+        }
+
+        "#});
+    mock.assert();
+}
+
+#[test]
 fn inferred_nonjson_output() {
     let server = MockServer::start();
     let mock = server.mock(|_when, then| {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -810,3 +810,18 @@ fn multipart_stdin() {
             "Cannot build a multipart request body from stdin",
         ));
 }
+
+#[test]
+fn default_json_for_raw_body() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, _then| {
+        when.header("content-type", "application/json");
+    });
+    let input_file = tempfile().unwrap();
+    redirecting_command()
+        .arg(server.base_url())
+        .stdin(input_file)
+        .assert()
+        .success();
+    mock.assert();
+}


### PR DESCRIPTION
- Default to a content type of `application/json` when reading a body from stdin. It already used to do this, but I broke it in #73.
  It might be worth a bugfix release, I'm not sure. 0e1c5a06f296a553078bfc08b9b13894da4846c6 is a minimal fix that could be cherrypicked.
- Highlight Javascript and CSS, since we're bundling the syntax files for them anyway.
- Check if text is actually JSON before formatting it.