### PR TITLE
Add support for getting credentials from .netrc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1318,12 @@ dependencies = [
  "libc",
  "socket2",
 ]
+
+[[package]]
+name = "netrc-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -2102,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
- "dirs",
+ "dirs 1.0.5",
  "winapi",
 ]
 
@@ -2622,6 +2648,7 @@ dependencies = [
  "assert_matches",
  "atty",
  "curl",
+ "dirs 3.0.1",
  "encoding_rs",
  "encoding_rs_io",
  "exit_status",
@@ -2632,6 +2659,7 @@ dependencies = [
  "memchr",
  "mime",
  "mime2ext",
+ "netrc-rs",
  "pem",
  "predicates",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ serde_json = "1.0"
 serde_urlencoded = "0.7.0"
 shell-escape = "0.1.5"
 structopt = "0.3"
+dirs = "3.0.1"
+netrc-rs = "0.1.2"
 
 [dependencies.syntect]
 version = "4.4"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -37,7 +37,6 @@ fn netrc_path() -> Option<PathBuf> {
                 [".netrc", "_netrc"]
                     .iter()
                     .map(|f| hd_path.join(f))
-                    .inspect(|p| println!("{:?}", p))
                     .find(|p| p.exists())
             } else {
                 None
@@ -107,8 +106,16 @@ mod tests {
             ),
             ("example.org", good_netrc, None),
             ("example.com", malformed_netrc, None),
-            ("example.com", missing_login, Some(("".to_string(), Some("pass".to_string())))),
-            ("example.com", missing_pass, Some(("user".to_string(), None))),
+            (
+                "example.com",
+                missing_login,
+                Some(("".to_string(), Some("pass".to_string()))),
+            ),
+            (
+                "example.com",
+                missing_pass,
+                Some(("user".to_string(), None)),
+            ),
         ];
 
         for (machine, netrc, output) in expected {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -23,7 +23,7 @@ pub fn parse_auth(auth: String, host: &str) -> io::Result<(String, Option<String
 }
 
 fn get_home_dir() -> Option<PathBuf> {
-    #[cfg(all(target_os = "win", test))]
+    #[cfg(target_os = "win")]
     if let Some(path) = env::var_os("XH_TEST_MODE_WIN_HOME_DIR") {
         return Some(PathBuf::from(path));
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -23,7 +23,7 @@ pub fn parse_auth(auth: String, host: &str) -> io::Result<(String, Option<String
 }
 
 fn get_home_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "win")]
+    #[cfg(target_os = "windows")]
     if let Some(path) = env::var_os("XH_TEST_MODE_WIN_HOME_DIR") {
         return Some(PathBuf::from(path));
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -26,7 +26,7 @@ pub fn read_netrc() -> Option<String> {
     if let Some(mut hd_path) = home_dir() {
         hd_path.push(".netrc");
         if let Ok(mut netrc_file) = File::open(hd_path) {
-            if let Ok(_) = netrc_file.read_to_string(&mut netrc_buf) {
+            if netrc_file.read_to_string(&mut netrc_buf).is_ok() {
                 return Some(netrc_buf);
             };
         };
@@ -61,9 +61,7 @@ pub fn auth_from_netrc(machine: &str, netrc: String) -> Option<(String, Option<S
             })
             .collect();
 
-        if auths.len() == 0 {
-            return None;
-        } else {
+        if !auths.is_empty() {
             return auths.pop();
         }
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -22,6 +22,15 @@ pub fn parse_auth(auth: String, host: &str) -> io::Result<(String, Option<String
     }
 }
 
+fn get_home_dir() -> Option<PathBuf> {
+    #[cfg(all(target_os = "win", test))]
+    if let Some(path) = env::var_os("XH_TEST_MODE_WIN_HOME_DIR") {
+        return Some(PathBuf::from(path));
+    }
+
+    home_dir()
+}
+
 fn netrc_path() -> Option<PathBuf> {
     match env::var_os("NETRC") {
         Some(path) => {
@@ -33,7 +42,7 @@ fn netrc_path() -> Option<PathBuf> {
             }
         }
         None => {
-            if let Some(hd_path) = home_dir() {
+            if let Some(hd_path) = get_home_dir() {
                 [".netrc", "_netrc"]
                     .iter()
                     .map(|f| hd_path.join(f))

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,11 +1,10 @@
 use std::io;
 
 use crate::regex;
-use std::fs::File;
-use std::io::Read;
 use dirs::home_dir;
 use netrc_rs::Netrc;
-
+use std::fs::File;
+use std::io::Read;
 
 pub fn parse_auth(auth: String, host: &str) -> io::Result<(String, Option<String>)> {
     if let Some(cap) = regex!(r"^([^:]*):$").captures(&auth) {
@@ -23,7 +22,6 @@ pub fn parse_auth(auth: String, host: &str) -> io::Result<(String, Option<String
 }
 
 pub fn read_netrc() -> Option<String> {
-
     let mut netrc_buf = String::new();
     if let Some(mut hd_path) = home_dir() {
         hd_path.push(".netrc");
@@ -38,29 +36,33 @@ pub fn read_netrc() -> Option<String> {
 }
 
 pub fn auth_from_netrc(machine: &str, netrc: String) -> Option<(String, Option<String>)> {
-
     if let Ok(netrc) = Netrc::parse_borrow(&netrc, false) {
-        let mut auths: Vec<(String, Option<String>)> = netrc.machines.iter()
-            .filter_map(|mach| if let Some(name) = &mach.name {
-                if name.ends_with(machine) {
-                    let user = match mach.login {
-                        Some(ref user) => user.clone(),
-                        None => "".to_string()
-                    };
-                    let password = match mach.password {
-                        Some(ref pwd) => Some(pwd.clone()),
-                        None => None
-                    };
-                    Some((user, password))
+        let mut auths: Vec<(String, Option<String>)> = netrc
+            .machines
+            .iter()
+            .filter_map(|mach| {
+                if let Some(name) = &mach.name {
+                    if name.ends_with(machine) {
+                        let user = match mach.login {
+                            Some(ref user) => user.clone(),
+                            None => "".to_string(),
+                        };
+                        let password = match mach.password {
+                            Some(ref pwd) => Some(pwd.clone()),
+                            None => None,
+                        };
+                        Some((user, password))
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
-            } else {
-                None
-            }).collect();
+            })
+            .collect();
 
         if auths.len() == 0 {
-            return None
+            return None;
         } else {
             return auths.pop();
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Cli {
     pub bearer: Option<String>,
 
     /// Do not use credentials from .netrc
-    #[structopt(long = "ignore-netrc")]
+    #[structopt(long)]
     pub ignore_netrc: bool,
 
     /// Save output to FILE instead of stdout.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,10 @@ pub struct Cli {
     #[structopt(long, value_name = "TOKEN")]
     pub bearer: Option<String>,
 
+    /// Do not use credentials from .netrc
+    #[structopt(long = "ignore-netrc")]
+    pub ignore_netrc: bool,
+
     /// Save output to FILE instead of stdout.
     #[structopt(short = "o", long, value_name = "FILE")]
     pub output: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,11 +187,11 @@ fn main() -> Result<i32> {
             let (username, password) = parse_auth(auth, url.host_str().unwrap_or("<host>"))?;
             request_builder = request_builder.basic_auth(username, password);
         } else if !args.ignore_netrc {
-            if let Some(netrc) = read_netrc() {
-                if let Some((username, password)) =
-                    auth_from_netrc(url.host_str().unwrap_or("<host>"), netrc)
-                {
-                    request_builder = request_builder.basic_auth(username, password);
+            if let Some(host) = url.host_str() {
+                if let Some(netrc) = read_netrc() {
+                    if let Some((username, password)) = auth_from_netrc(host, &netrc) {
+                        request_builder = request_builder.basic_auth(username, password);
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use reqwest::header::{
 };
 use reqwest::redirect::Policy;
 
-use crate::auth::parse_auth;
+use crate::auth::{read_netrc, auth_from_netrc, parse_auth};
 use crate::buffer::Buffer;
 use crate::cli::{Cli, Pretty, Print, Proxy, RequestType, Theme, Verify};
 use crate::download::{download_file, get_file_size};
@@ -186,6 +186,14 @@ fn main() -> Result<i32> {
         if let Some(auth) = args.auth {
             let (username, password) = parse_auth(auth, url.host_str().unwrap_or("<host>"))?;
             request_builder = request_builder.basic_auth(username, password);
+        } else {
+            if !args.ignore_netrc {
+                if let Some(netrc) = read_netrc() {
+                    if let Some((username, password)) = auth_from_netrc(url.host_str().unwrap_or("<host>"), netrc) {
+                        request_builder = request_builder.basic_auth(username, password);
+                    }
+                }
+            }
         }
         if let Some(token) = args.bearer {
             request_builder = request_builder.bearer_auth(token);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use reqwest::header::{
 };
 use reqwest::redirect::Policy;
 
-use crate::auth::{read_netrc, auth_from_netrc, parse_auth};
+use crate::auth::{auth_from_netrc, parse_auth, read_netrc};
 use crate::buffer::Buffer;
 use crate::cli::{Cli, Pretty, Print, Proxy, RequestType, Theme, Verify};
 use crate::download::{download_file, get_file_size};
@@ -189,7 +189,9 @@ fn main() -> Result<i32> {
         } else {
             if !args.ignore_netrc {
                 if let Some(netrc) = read_netrc() {
-                    if let Some((username, password)) = auth_from_netrc(url.host_str().unwrap_or("<host>"), netrc) {
+                    if let Some((username, password)) =
+                        auth_from_netrc(url.host_str().unwrap_or("<host>"), netrc)
+                    {
                         request_builder = request_builder.basic_auth(username, password);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,14 +186,12 @@ fn main() -> Result<i32> {
         if let Some(auth) = args.auth {
             let (username, password) = parse_auth(auth, url.host_str().unwrap_or("<host>"))?;
             request_builder = request_builder.basic_auth(username, password);
-        } else {
-            if !args.ignore_netrc {
-                if let Some(netrc) = read_netrc() {
-                    if let Some((username, password)) =
-                        auth_from_netrc(url.host_str().unwrap_or("<host>"), netrc)
-                    {
-                        request_builder = request_builder.basic_auth(username, password);
-                    }
+        } else if !args.ignore_netrc {
+            if let Some(netrc) = read_netrc() {
+                if let Some((username, password)) =
+                    auth_from_netrc(url.host_str().unwrap_or("<host>"), netrc)
+                {
+                    request_builder = request_builder.basic_auth(username, password);
                 }
             }
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -557,7 +557,6 @@ fn netrc_env_user_password_auth() {
 
 #[test]
 fn netrc_file_user_password_auth() {
-
     for netrc_file in [".netrc", "_netrc"].iter() {
         let server = MockServer::start();
         let mock = server.mock(|when, _then| {
@@ -572,7 +571,7 @@ fn netrc_file_user_password_auth() {
             "machine {}\nlogin user\npassword pass",
             server.host()
         )
-            .unwrap();
+        .unwrap();
 
         netrc.flush().unwrap();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -540,7 +540,12 @@ fn netrc_user_password_auth() {
     });
 
     let mut netrc = tempfile::NamedTempFile::new().unwrap();
-    writeln!(netrc, "machine {}\nlogin user\npassword pass", server.host()).unwrap();
+    writeln!(
+        netrc,
+        "machine {}\nlogin user\npassword pass",
+        server.host()
+    )
+    .unwrap();
 
     get_command()
         .env("NETRC", netrc.path().to_str().unwrap())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -533,6 +533,23 @@ fn user_password_auth() {
 }
 
 #[test]
+fn netrc_user_password_auth() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, _then| {
+        when.header("Authorization", "Basic dXNlcjpwYXNz");
+    });
+
+    let mut netrc = tempfile::NamedTempFile::new().unwrap();
+    writeln!(netrc, "machine {}\nlogin user\npassword pass", server.host()).unwrap();
+
+    get_command()
+        .env("NETRC", netrc.path().to_str().unwrap())
+        .arg(server.base_url())
+        .assert();
+    mock.assert();
+}
+
+#[test]
 fn check_status_warning() {
     let server = MockServer::start();
     let mock = server.mock(|_when, then| {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,7 +14,9 @@ use serde_json::json;
 use tempfile::{tempdir, tempfile};
 
 fn get_base_command() -> Command {
-    Command::cargo_bin("xh").expect("binary should be present")
+    let mut cmd = Command::cargo_bin("xh").expect("binary should be present");
+    cmd.env("HOME", "");
+    cmd
 }
 
 /// Sensible default command to test with. use [`get_base_command`] if this

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,7 +17,7 @@ use tempfile::{tempdir, tempfile};
 fn get_base_command() -> Command {
     let mut cmd = Command::cargo_bin("xh").expect("binary should be present");
     cmd.env("HOME", "");
-    #[cfg(target_os = "win")]
+    #[cfg(target_os = "windows")]
     cmd.env("XH_TEST_MODE_WIN_HOME_DIR", "");
     cmd
 }
@@ -577,17 +577,12 @@ fn netrc_file_user_password_auth() {
 
         netrc.flush().unwrap();
 
-        #[cfg(target_os = "win")]
         get_command()
+            .env("HOME", homedir.path())
             .env("XH_TEST_MODE_WIN_HOME_DIR", homedir.path())
             .arg(server.base_url())
             .assert();
 
-        #[cfg(not(target_os = "win"))]
-        get_command()
-            .env("HOME", homedir.path())
-            .arg(server.base_url())
-            .assert();
         mock.assert();
 
         drop(netrc);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,6 +17,8 @@ use tempfile::{tempdir, tempfile};
 fn get_base_command() -> Command {
     let mut cmd = Command::cargo_bin("xh").expect("binary should be present");
     cmd.env("HOME", "");
+    #[cfg(target_os = "win")]
+    cmd.env("XH_TEST_MODE_WIN_HOME_DIR", "");
     cmd
 }
 
@@ -575,6 +577,13 @@ fn netrc_file_user_password_auth() {
 
         netrc.flush().unwrap();
 
+        #[cfg(target_os = "win")]
+        get_command()
+            .env("XH_TEST_MODE_WIN_HOME_DIR", homedir.path())
+            .arg(server.base_url())
+            .assert();
+
+        #[cfg(not(target_os = "win"))]
         get_command()
             .env("HOME", homedir.path())
             .arg(server.base_url())


### PR DESCRIPTION
Addresses #52 .

Adds a `--ignore-netrc` cli option to disable the functionality (same as [httpie](https://httpie.io/docs#netrc)).

I'll update with some tests, but wanted to see if the approach overall was good.