### PR TITLE
Support non-standard HTTP methods

### DIFF
--- a/assets/http.sublime-syntax
+++ b/assets/http.sublime-syntax
@@ -44,7 +44,7 @@ contexts:
         2: storage.type.class.metadata
         3: punctuation.definition.block.tag.metadata
         4: entity.name.type.instance.metadata
-    - match: ^(?:((?i)get|post|put|delete|patch|head|options|connect|trace(-?))\s+)?\s*(\S+)(?:\s+(((?i)HTTP(-?))\/(\S+)))?$
+    - match: ^(?:([a-zA-Z]+(-?))\s+)?\s*(\S+)(?:\s+(((?i)HTTP(-?))\/(\S+)))?$
       scope: http.requestline
       captures:
         1: keyword.control.http

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fs::read_dir;
 use std::path::Path;
 
 use syntect::dumps::*;
@@ -7,6 +8,12 @@ use syntect::parsing::SyntaxSetBuilder;
 
 fn main() {
     println!("cargo:rerun-if-changed=assets");
+    for entry in read_dir("assets").unwrap() {
+        println!(
+            "cargo:rerun-if-changed={}",
+            entry.unwrap().path().to_str().unwrap()
+        );
+    }
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     let mut builder = SyntaxSetBuilder::new();

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSetBuilder;
 
 fn main() {
+    println!("cargo:rerun-if-changed=assets");
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     let mut builder = SyntaxSetBuilder::new();


### PR DESCRIPTION
Earlier (#69) I introduced a hardcoded list of valid HTTP methods, while HTTPie simply matches against `[a-zA-Z]+`. But weird HTTP methods are a bit more common than I thought, see [varnish](https://varnish-cache.org/docs/3.0/tutorial/purging.html) (httpie/httpie#693). The current system doesn't let you use weird HTTP methods at all, so HTTPie's way seems better.

That unfortunately means `xh localhost` no longer does what you want.

I've made the same change to the highlighting syntax file. I don't think that breaks anything.