### PR TITLE
Replace StructOpt with clap-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,15 +32,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -451,17 +442,34 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
- "ansi_term 0.11.0",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1397,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,33 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -2080,6 +2070,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -2576,11 +2575,12 @@ dependencies = [
 name = "xh"
 version = "0.8.1"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "anyhow",
  "assert_cmd",
  "assert_matches",
  "atty",
+ "clap",
  "curl",
  "encoding_rs",
  "encoding_rs_io",
@@ -2601,7 +2601,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "shell-escape",
- "structopt",
  "syntect",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ readme = "README.md"
 ansi_term = "0.12"
 anyhow = "1.0.38"
 atty = "0.2"
+clap = { version = "3.0.0-beta.2" }
 encoding_rs = "0.8.28"
 encoding_rs_io = "0.1.7"
 exit_status = "0.1.0"
 indicatif = "0.15.0"
+indoc = "1.0"
 lazy_static = "1.4.0"
 memchr = "2.3.4"
 mime = "0.3.16"
@@ -30,7 +32,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.7.0"
 shell-escape = "0.1.5"
-structopt = "0.3"
 
 [dependencies.syntect]
 version = "4.4"
@@ -41,7 +42,6 @@ features = ["parsing", "html", "yaml-load", "dump-load", "dump-create", "regex-o
 # Some are only needed for the `integration-tests` feature, but dev-dependencies can't be optional
 assert_cmd = "1.0"
 assert_matches = "1.4.0"
-indoc = "1.0"
 predicates = "1.0.7"
 httpmock = "0.5.5"
 curl = { version = "0.4.34", features = ["static-ssl"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,15 +8,15 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use reqwest::{Method, Url};
-use structopt::clap::{self, arg_enum, AppSettings, Error, ErrorKind, Result};
-use structopt::StructOpt;
+use clap::{self, FromArgMatches, AppSettings, Error, ErrorKind, Result};
+use clap::Clap;
 
 use crate::{buffer::Buffer, request_items::RequestItem, utils::test_pretend_term};
 
 // Some doc comments were copy-pasted from HTTPie
 
-// structopt guidelines:
-// - Only use `short` with an explicit arg (`short = "x"`)
+// Clap guidelines:
+// - Only use `short` with an explicit arg (`short = 'x'`)
 // - Only use `long` with an implicit arg (just `long`)
 //   - Unless it needs a different name, but then also use `name = "..."`
 // - Add an uppercase value_name to options that take a value
@@ -24,74 +24,73 @@ use crate::{buffer::Buffer, request_items::RequestItem, utils::test_pretend_term
 /// xh is a friendly and fast tool for sending HTTP requests.
 ///
 /// It reimplements as much as possible of HTTPie's excellent design.
-#[derive(StructOpt, Debug)]
-#[structopt(name = "xh", setting = AppSettings::DeriveDisplayOrder)]
+#[derive(Clap, Debug)]
+#[clap(name = "xh", setting = AppSettings::DeriveDisplayOrder)]
 pub struct Cli {
     /// Construct HTTP requests without sending them anywhere.
-    #[structopt(long)]
+    #[clap(long)]
     pub offline: bool,
 
     /// (default) Serialize data items from the command line as a JSON object.
-    #[structopt(short = "j", long, overrides_with_all = &["form", "multipart"])]
+    #[clap(short = 'j', long, overrides_with_all = &["form", "multipart"])]
     pub json: bool,
 
     /// Serialize data items from the command line as form fields.
-    #[structopt(short = "f", long, overrides_with_all = &["json", "multipart"])]
+    #[clap(short = 'f', long, overrides_with_all = &["json", "multipart"])]
     pub form: bool,
 
     /// Like --form, but force a multipart/form-data request even without files.
-    #[structopt(short = "m", long, overrides_with_all = &["json", "form"])]
+    #[clap(short = 'm', long, overrides_with_all = &["json", "form"])]
     pub multipart: bool,
 
-    #[structopt(skip)]
+    #[clap(skip)]
     pub request_type: RequestType,
 
     /// Do not attempt to read stdin.
-    #[structopt(short = "I", long)]
+    #[clap(short = 'I', long)]
     pub ignore_stdin: bool,
 
     // Currently deprecated in favor of --bearer, un-hide if new auth types are introduced
     /// Specify the auth mechanism.
-    #[structopt(short = "A", long, possible_values = &AuthType::variants(),
-                default_value = "basic", case_insensitive = true, hidden = true)]
+    #[clap(short = 'A', long, arg_enum, default_value = "basic", hidden = true)]
     pub auth_type: AuthType,
 
     /// Authenticate as USER with PASS. PASS will be prompted if missing.
     ///
     /// Use a trailing colon (i.e. `USER:`) to authenticate with just a username.
-    #[structopt(short = "a", long, value_name = "USER[:PASS]")]
+    #[clap(short = 'a', long, value_name = "USER[:PASS]")]
     pub auth: Option<String>,
 
     /// Authenticate with a bearer token.
-    #[structopt(long, value_name = "TOKEN")]
+    #[clap(long, value_name = "TOKEN")]
     pub bearer: Option<String>,
 
     /// Save output to FILE instead of stdout.
-    #[structopt(short = "o", long, value_name = "FILE")]
+    #[clap(short = 'o', long, value_name = "FILE")]
     pub output: Option<String>,
 
     /// Do follow redirects.
-    #[structopt(short = "F", long)]
+    #[clap(short = 'F', long)]
     pub follow: bool,
 
     /// Number of redirects to follow, only respected if `follow` is set.
-    #[structopt(long, value_name = "NUM")]
+    #[clap(long, value_name = "NUM")]
     pub max_redirects: Option<usize>,
 
     /// Download the body to a file instead of printing it.
-    #[structopt(short = "d", long)]
+    #[clap(short = 'd', long)]
     pub download: bool,
 
     /// Print only the response headers, shortcut for --print=h.
-    #[structopt(short = "h", long)]
+    #[clap(short = 'h', long)]
     pub headers: bool,
 
     /// Print only the response body, Shortcut for --print=b.
-    #[structopt(short = "b", long)]
+    #[clap(short = 'b', long)]
     pub body: bool,
 
     /// Resume an interrupted download. Requires --download and --output.
-    #[structopt(short = "c", long = "continue", name = "continue")]
+    #[clap(short = 'c', long = "continue", name = "continue")]
     pub resume: bool,
 
     /// String specifying what the output should contain.
@@ -100,27 +99,27 @@ pub struct Cli {
     /// and `h` and `b` for response hader and body.
     ///
     /// Example: `--print=Hb`
-    #[structopt(short = "p", long, value_name = "FORMAT")]
+    #[clap(short = 'p', long, value_name = "FORMAT")]
     pub print: Option<Print>,
 
     /// Print the whole request as well as the response.
-    #[structopt(short = "v", long)]
+    #[clap(short = 'v', long)]
     pub verbose: bool,
 
     /// Do not print to stdout or stderr.
-    #[structopt(short = "q", long)]
+    #[clap(short = 'q', long)]
     pub quiet: bool,
 
     /// Always stream the response body.
-    #[structopt(short = "S", long)]
+    #[clap(short = 'S', long)]
     pub stream: bool,
 
     /// Controls output processing.
-    #[structopt(long, possible_values = &Pretty::variants(), case_insensitive = true, value_name = "STYLE")]
+    #[clap(long, arg_enum, value_name = "STYLE")]
     pub pretty: Option<Pretty>,
 
     /// Output coloring style.
-    #[structopt(short = "s", long, value_name = "THEME", possible_values = &Theme::variants(), case_insensitive = true)]
+    #[clap(short = 's', long, arg_enum, value_name = "THEME")]
     pub style: Option<Theme>,
 
     /// Exit with an error status code if the server replies with an error.
@@ -129,17 +128,17 @@ pub struct Cli {
     /// or 3 on 3xx (Redirect) if --follow isn't set.
     ///
     /// If stdout is redirected then a warning is written to stderr.
-    #[structopt(long)]
+    #[clap(long)]
     pub check_status: bool,
 
     /// Print a translation to a `curl` command.
     ///
     /// For translating the other way, try https://curl2httpie.online/.
-    #[structopt(long)]
+    #[clap(long)]
     pub curl: bool,
 
     /// Use the long versions of curl's flags.
-    #[structopt(long)]
+    #[clap(long)]
     pub curl_long: bool,
 
     /// Use a proxy for a protocol. For example: `--proxy https:http://proxy.host:8080`.
@@ -153,53 +152,59 @@ pub struct Cli {
     ///
     /// The environment variables `http_proxy` and `https_proxy` can also be used, but
     /// are completely ignored if --proxy is passed.
-    #[structopt(long, value_name = "PROTOCOL:URL", number_of_values = 1)]
+    #[clap(long, value_name = "PROTOCOL:URL", number_of_values = 1)]
     pub proxy: Vec<Proxy>,
 
     /// The default scheme to use if not specified in the URL.
-    #[structopt(long, value_name = "SCHEME", hidden = true)]
+    #[clap(long, value_name = "SCHEME", hidden = true)]
     pub default_scheme: Option<String>,
 
     /// Make HTTPS requests if not specified in the URL.
-    #[structopt(long)]
+    #[clap(long)]
     pub https: bool,
 
     /// The request URL, preceded by an optional HTTP method.
-    ///
-    /// METHOD can be `get`, `post`, `head`, `put`, `patch`, `delete` or `options`.
-    /// If omitted, either a GET or a POST will be done depending on whether the
-    /// request sends data.
-    #[structopt(value_name = "[METHOD] URL")]
+    #[clap(
+        value_name = "[METHOD] URL",
+        long_about = indoc::indoc!{"
+            The request URL, preceded by an optional HTTP method.
+
+            METHOD can be `get`, `post`, `head`, `put`, `patch`, `delete` or `options`.
+            If omitted, either a GET or a POST will be done depending on whether the
+            request sends data.\n\n
+        "}
+    )]
     raw_method_or_url: String,
 
     /// Optional key-value pairs to be included in the request.
-    #[structopt(
+    #[clap(
         value_name = "REQUEST_ITEM",
-        long_help = r"Optional key-value pairs to be included in the request.
+        long_about = indoc::indoc!{r"
+            Optional key-value pairs to be included in the request.
 
-- key==value to add a parameter to the URL
-- key=value to add a JSON field (--json) or form field (--form)
-- key:=value to add a complex JSON value (e.g. `numbers:=[1,2,3]`)
-- key@filename to upload a file from filename (with --form)
-- header:value to add a header
-- header: to unset a header
-- header; to add a header with an empty value
+            - key==value to add a parameter to the URL
+            - key=value to add a JSON field (--json) or form field (--form)
+            - key:=value to add a complex JSON value (e.g. `numbers:=[1,2,3]`)
+            - key@filename to upload a file from filename (with --form)
+            - header:value to add a header
+            - header: to unset a header
+            - header; to add a header with an empty value
 
-A backslash can be used to escape special characters (e.g. weird\:key=value).
-"
+            A backslash can be used to escape special characters (e.g. weird\:key=value).
+        "}
     )]
     raw_rest_args: Vec<String>,
 
     /// The HTTP method, if supplied.
-    #[structopt(skip)]
+    #[clap(skip)]
     pub method: Option<Method>,
 
     /// The request URL.
-    #[structopt(skip)]
+    #[clap(skip)]
     pub url: String,
 
     /// Optional key-value pairs to be included in the request.
-    #[structopt(skip)]
+    #[clap(skip)]
     pub request_items: Vec<RequestItem>,
 
     /// If "no", skip SSL verification. If a file path, use it as a CA bundle.
@@ -207,17 +212,17 @@ A backslash can be used to escape special characters (e.g. weird\:key=value).
     /// Specifying a CA bundle will disable the system's built-in root certificates.
     ///
     /// "false" instead of "no" also works. The default is "yes" ("true").
-    #[structopt(long, default_value, hide_default_value = true, value_name = "VERIFY")]
+    #[clap(long, default_value, hide_default_value = true, value_name = "VERIFY")]
     pub verify: Verify,
 
     /// Use a client side certificate for SSL.
-    #[structopt(long, value_name = "FILE")]
+    #[clap(long, value_name = "FILE")]
     pub cert: Option<PathBuf>,
 
     /// A private key file to use with --cert.
     ///
     /// Only necessary if the private key is not contained in the cert file.
-    #[structopt(long, value_name = "FILE")]
+    #[clap(long, value_name = "FILE")]
     pub cert_key: Option<PathBuf>,
 }
 
@@ -264,21 +269,21 @@ const NEGATION_FLAGS: &[&str] = &[
 ];
 
 impl Cli {
-    pub fn from_args() -> Self {
-        Cli::from_iter(std::env::args())
+    pub fn parse() -> Self {
+        Cli::parse_from(std::env::args())
     }
 
-    pub fn from_iter<I>(iter: I) -> Self
+    pub fn parse_from<I>(iter: I) -> Self
     where
         I: IntoIterator,
         I::Item: Into<OsString> + Clone,
     {
-        match Self::from_iter_safe(iter) {
+        match Self::try_parse_from(iter) {
             Ok(cli) => cli,
-            Err(err) if err.kind == ErrorKind::HelpDisplayed => {
+            Err(err) if err.kind == ErrorKind::DisplayHelp => {
                 // The logic here is a little tricky.
                 //
-                // Normally with structopt/clap, -h prints short help while --help
+                // Normally with clap, -h prints short help while --help
                 // prints long help.
                 //
                 // But -h is short for --header, so we want --help to print short help
@@ -289,8 +294,8 @@ impl Cli {
                 // want to print long help, then we insert our own error in from_iter_safe
                 // with a special tag.
                 if env::var_os("XH_HELP2MAN").is_some() {
-                    Cli::clap()
-                        .template(
+                    Cli::into_app()
+                        .help_template(
                             "\
                                 Usage: {usage}\n\
                                 \n\
@@ -304,15 +309,15 @@ impl Cli {
                         )
                         .print_long_help()
                         .unwrap();
-                } else if err.message == "XH_PRINT_LONG_HELP" {
-                    Cli::clap().print_long_help().unwrap();
-                    println!();
+                // } else if err.description == "XH_PRINT_LONG_HELP" {
                 } else {
-                    Cli::clap().print_help().unwrap();
-                    println!(
-                        "\n\nRun `{} help` for more complete documentation.",
-                        env!("CARGO_PKG_NAME")
-                    );
+                    Cli::into_app().print_long_help().unwrap();
+                    println!();
+                    // Cli::into_app().print_help().unwrap();
+                    // println!(
+                    //     "\n\nRun `{} help` for more complete documentation.",
+                    //     env!("CARGO_PKG_NAME")
+                    // );
                 }
                 safe_exit();
             }
@@ -320,25 +325,21 @@ impl Cli {
         }
     }
 
-    pub fn from_iter_safe<I>(iter: I) -> clap::Result<Self>
+    pub fn try_parse_from<I>(iter: I) -> clap::Result<Self>
     where
         I: IntoIterator,
         I::Item: Into<OsString> + Clone,
     {
-        let mut app = Self::clap();
-        let matches = app.get_matches_from_safe_borrow(iter)?;
-        let mut cli = Self::from_clap(&matches);
+        let mut app = Self::into_app();
+        let matches = app.try_get_matches_from_mut(iter)?;
+        let mut cli = Self::from_arg_matches(&matches);
 
         match cli.raw_method_or_url.as_str() {
-            "help" => {
-                return Err(Error {
-                    message: "XH_PRINT_LONG_HELP".to_string(),
-                    kind: ErrorKind::HelpDisplayed,
-                    info: Some(vec!["XH_PRINT_LONG_HELP".to_string()]),
-                })
-            }
-            "print_completions" => return Err(print_completions(app, cli.raw_rest_args)),
-            "generate_completions" => return Err(generate_completions(app, cli.raw_rest_args)),
+            "help" => return Err(
+                Error::with_description("XH_PRINT_LONG_HELP".into(), ErrorKind::DisplayHelp)
+            ),
+            // "print_completions" => return Err(print_completions(app, cli.raw_rest_args)),
+            // "generate_completions" => return Err(generate_completions(app, cli.raw_rest_args)),
             _ => {}
         }
         let mut rest_args = mem::take(&mut cli.raw_rest_args).into_iter();
@@ -346,7 +347,7 @@ impl Cli {
             Some(method) => {
                 cli.method = Some(method);
                 cli.url = rest_args.next().ok_or_else(|| {
-                    Error::with_description("Missing URL", ErrorKind::MissingArgumentOrSubcommand)
+                    Error::with_description("Missing URL".into(), ErrorKind::MissingArgumentOrSubcommand)
                 })?;
             }
             None => {
@@ -373,13 +374,13 @@ impl Cli {
     fn process_relations(&mut self) -> clap::Result<()> {
         if self.resume && !self.download {
             return Err(Error::with_description(
-                "--continue only works with --download",
+                "--continue only works with --download".into(),
                 ErrorKind::MissingArgumentOrSubcommand,
             ));
         }
         if self.resume && self.output.is_none() {
             return Err(Error::with_description(
-                "--continue requires --output",
+                "--continue requires --output".into(),
                 ErrorKind::MissingArgumentOrSubcommand,
             ));
         }
@@ -407,8 +408,8 @@ impl Cli {
         Ok(())
     }
 
-    pub fn clap() -> clap::App<'static, 'static> {
-        let mut app = <Self as StructOpt>::clap();
+    pub fn into_app() -> clap::App<'static> {
+        let mut app = <Cli as clap::IntoApp>::into_app();
         for &flag in NEGATION_FLAGS {
             // `orig` and `flag` both need a static lifetime, so we
             // build `orig` by trimming `flag` instead of building `flag`
@@ -417,7 +418,7 @@ impl Cli {
             app = app.arg(
                 // The name is inconsequential, but it has to be unique and it
                 // needs a static lifetime, and `flag` satisfies that
-                clap::Arg::with_name(flag)
+                clap::Arg::new(flag)
                     .long(flag)
                     .hidden(true)
                     // overrides_with is enough to make the flags take effect
@@ -441,74 +442,70 @@ fn parse_method(method: &str) -> Option<Method> {
     }
 }
 
-// This signature is a little weird: we either return an error or don't
-// return at all
-fn print_completions(mut app: clap::App, rest_args: Vec<String>) -> Error {
-    let bin_name = match app.get_bin_name() {
-        // This name is borrowed from `app`, and `gen_completions_to()` mutably
-        // borrows `app`, so we need to do a clone
-        Some(name) => name.to_owned(),
-        None => return Error::with_description("Missing binary name", ErrorKind::EmptyValue),
-    };
-    if rest_args.len() != 1 {
-        return Error::with_description(
-            "Usage: xh print_completions <SHELL>",
-            ErrorKind::WrongNumberOfValues,
-        );
-    }
-    let shell = match rest_args[0].parse() {
-        Ok(shell) => shell,
-        Err(_) => return Error::with_description("Unknown shell name", ErrorKind::InvalidValue),
-    };
-    let mut buf = Vec::new();
-    app.gen_completions_to(bin_name, shell, &mut buf);
-    let mut completions = String::from_utf8(buf).unwrap();
-    if matches!(shell, clap::Shell::Fish) {
-        // We don't have (proper) subcommands, so this check is unnecessary and
-        // slightly harmful
-        // See https://github.com/clap-rs/clap/pull/2359, currently unreleased
-        completions = completions.replace(r#" -n "__fish_use_subcommand""#, "");
-    }
-    print!("{}", completions);
-    safe_exit();
+// // This signature is a little weird: we either return an error or don't
+// // return at all
+// fn print_completions(mut app: clap::App, rest_args: Vec<String>) -> Error {
+//     let bin_name = match app.get_bin_name() {
+//         // This name is borrowed from `app`, and `gen_completions_to()` mutably
+//         // borrows `app`, so we need to do a clone
+//         Some(name) => name.to_owned(),
+//         None => return Error::with_description("Missing binary name".into(), ErrorKind::EmptyValue),
+//     };
+//     if rest_args.len() != 1 {
+//         return Error::with_description(
+//             "Usage: xh print_completions <SHELL>".into(),
+//             ErrorKind::WrongNumberOfValues,
+//         );
+//     }
+//     let shell = match rest_args[0].parse() {
+//         Ok(shell) => shell,
+//         Err(_) => return Error::with_description("Unknown shell name".into(), ErrorKind::InvalidValue),
+//     };
+//     let mut buf = Vec::new();
+//     app.gen_completions_to(bin_name, shell, &mut buf);
+//     let mut completions = String::from_utf8(buf).unwrap();
+//     if matches!(shell, clap::Shell::Fish) {
+//         // We don't have (proper) subcommands, so this check is unnecessary and
+//         // slightly harmful
+//         // See https://github.com/clap-rs/clap/pull/2359, currently unreleased
+//         completions = completions.replace(r#" -n "__fish_use_subcommand""#, "");
+//     }
+//     print!("{}", completions);
+//     safe_exit();
+// }
+
+// fn generate_completions(mut app: clap::App, rest_args: Vec<String>) -> Error {
+//     let bin_name = match app.get_bin_name() {
+//         Some(name) => name.to_owned(),
+//         None => return Error::with_description("Missing binary name".into(), ErrorKind::EmptyValue),
+//     };
+//     if rest_args.len() != 1 {
+//         return Error::with_description(
+//             "Usage: xh generate_completions <DIRECTORY>".into(),
+//             ErrorKind::WrongNumberOfValues,
+//         );
+//     }
+//     for &shell in &clap::Shell::variants() {
+//         // Elvish complains about multiple deprecations and these don't seem to work
+//         // If you must use them, generate them manually with xh print_completions elvish
+//         if shell != "elvish" {
+//             app.gen_completions(&bin_name, shell.parse().unwrap(), &rest_args[0]);
+//         }
+//     }
+//     safe_exit();
+// }
+
+#[allow(non_camel_case_types)]
+#[derive(Clap, Debug, PartialEq)]
+pub enum AuthType {
+    basic, bearer
 }
 
-fn generate_completions(mut app: clap::App, rest_args: Vec<String>) -> Error {
-    let bin_name = match app.get_bin_name() {
-        Some(name) => name.to_owned(),
-        None => return Error::with_description("Missing binary name", ErrorKind::EmptyValue),
-    };
-    if rest_args.len() != 1 {
-        return Error::with_description(
-            "Usage: xh generate_completions <DIRECTORY>",
-            ErrorKind::WrongNumberOfValues,
-        );
-    }
-    for &shell in &clap::Shell::variants() {
-        // Elvish complains about multiple deprecations and these don't seem to work
-        // If you must use them, generate them manually with xh print_completions elvish
-        if shell != "elvish" {
-            app.gen_completions(&bin_name, shell.parse().unwrap(), &rest_args[0]);
-        }
-    }
-    safe_exit();
-}
-
-arg_enum! {
-    #[allow(non_camel_case_types)]
-    #[derive(Debug, PartialEq)]
-    pub enum AuthType {
-        basic, bearer
-    }
-}
-
-arg_enum! {
-    // Uppercase variant names would show up as such in the help text
-    #[allow(non_camel_case_types)]
-    #[derive(Debug, PartialEq, Clone, Copy)]
-    pub enum Pretty {
-        all, colors, format, none
-    }
+// Uppercase variant names would show up as such in the help text
+#[allow(non_camel_case_types)]
+#[derive(Clap, Debug, PartialEq, Clone, Copy)]
+pub enum Pretty {
+    all, colors, format, none
 }
 
 impl Pretty {
@@ -538,12 +535,10 @@ impl From<&Buffer> for Pretty {
     }
 }
 
-arg_enum! {
-    #[allow(non_camel_case_types)]
-    #[derive(Debug, PartialEq, Clone, Copy)]
-    pub enum Theme {
-        auto, solarized
-    }
+#[allow(non_camel_case_types)]
+#[derive(Clap, Debug, PartialEq, Clone, Copy)]
+pub enum Theme {
+    auto, solarized
 }
 
 impl Theme {
@@ -634,7 +629,7 @@ impl FromStr for Print {
                 'b' => response_body = true,
                 char => {
                     return Err(Error::with_description(
-                        &format!("{:?} is not a valid value", char),
+                        format!("{:?} is not a valid value", char),
                         ErrorKind::InvalidValue,
                     ))
                 }
@@ -667,7 +662,7 @@ impl FromStr for Proxy {
             [protocol, url] => {
                 let url = reqwest::Url::try_from(url).map_err(|e| {
                     Error::with_description(
-                        &format!(
+                        format!(
                             "Invalid proxy URL '{}' for protocol '{}': {}",
                             url, protocol, e
                         ),
@@ -680,13 +675,13 @@ impl FromStr for Proxy {
                     "https" => Ok(Proxy::Https(url)),
                     "all" => Ok(Proxy::All(url)),
                     _ => Err(Error::with_description(
-                        &format!("Unknown protocol to set a proxy for: {}", protocol),
+                        format!("Unknown protocol to set a proxy for: {}", protocol),
                         ErrorKind::InvalidValue,
                     )),
                 }
             }
             _ => Err(Error::with_description(
-                "The value passed to --proxy should be formatted as <PROTOCOL>:<PROXY_URL>",
+                "The value passed to --proxy should be formatted as <PROTOCOL>:<PROXY_URL>".into(),
                 ErrorKind::InvalidValue,
             )),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn get_user_agent() -> &'static str {
 
 #[exit_status::main]
 fn main() -> Result<i32> {
-    let args = Cli::from_args();
+    let args = Cli::parse();
 
     if args.curl {
         to_curl::print_curl_translation(args)?;

--- a/src/request_items.rs
+++ b/src/request_items.rs
@@ -3,7 +3,6 @@ use std::{fs::File, io, path::Path, str::FromStr};
 use anyhow::{anyhow, Result};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{blocking::multipart, Method};
-use structopt::clap;
 
 use crate::cli::RequestType;
 
@@ -83,7 +82,7 @@ impl FromStr for RequestItem {
                     key,
                     serde_json::from_str(&value).map_err(|err| {
                         clap::Error::with_description(
-                            &format!("{:?}: {}", request_item, err),
+                            format!("{:?}: {}", request_item, err),
                             clap::ErrorKind::InvalidValue,
                         )
                     })?,
@@ -117,7 +116,7 @@ impl FromStr for RequestItem {
             // and was interpreted as a URL, making the actual URL a request
             // item
             Err(clap::Error::with_description(
-                &format!("{:?} is not a valid request item", request_item),
+                format!("{:?} is not a valid request item", request_item),
                 clap::ErrorKind::InvalidValue,
             ))
         }


### PR DESCRIPTION
I found this [file](https://github.com/clap-rs/clap/blob/602c79fecdf9b12071b3040f04e81ffefe1d77f3/clap_up/src/lib.rs) helpful for the migration from StructOpt to clap-derive. Although, now I am realizing that all of this could have been done automatically by running `cargo up dep clap`.