### PR TITLE
Escape backslash in JSON highlighting definition

### DIFF
--- a/assets/basic/json.sublime-syntax
+++ b/assets/basic/json.sublime-syntax
@@ -16,7 +16,7 @@ contexts:
         - meta_scope: comment.block.jsonkv
         - match: \*/
           pop: true
-    - match: '(")(?i)([^\"]+)(")\s*?:'
+    - match: '(")(?i)([^\\"]+)(")\s*?:'
       comment: Key names
       captures:
         1: keyword.other.name.jsonkv.start


### PR DESCRIPTION
This fixes the highlighting getting confused by `\":` inside a string, as seen when running `xh --offline : 'x=":'`.