### PR TITLE
Add more buffering and make piped output more consistent with HTTPie

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ xh -d httpbin.org/json -o res.json
 - `rustls` is used instead of the system's TLS library.
 - Headers are sent and printed in lowercase.
 - JSON keys are not sorted.
+- Formatted output is always UTF-8.
 
 ## Similar Projects
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,13 +30,22 @@ pub enum ContentType {
     Text,
     UrlencodedForm,
     Multipart,
+    Unknown,
 }
 
-pub fn get_content_type(headers: &HeaderMap) -> Option<ContentType> {
+impl ContentType {
+    pub fn is_text(&self) -> bool {
+        !matches!(
+            self,
+            ContentType::Unknown | ContentType::UrlencodedForm | ContentType::Multipart
+        )
+    }
+}
+
+pub fn get_content_type(headers: &HeaderMap) -> ContentType {
     headers
-        .get(CONTENT_TYPE)?
-        .to_str()
-        .ok()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
         .and_then(|content_type| {
             if content_type.contains("json") {
                 Some(ContentType::Json)
@@ -62,6 +71,7 @@ pub fn get_content_type(headers: &HeaderMap) -> Option<ContentType> {
                 None
             }
         })
+        .unwrap_or(ContentType::Unknown)
 }
 
 // https://stackoverflow.com/a/45145246/5915221


### PR DESCRIPTION
- Wrapping a `LineWriter` around `File`s gives a nice speedup if the output is formatted or colored, because that avoids doing lots of small writes. That means all output is now line-buffered one way or another.
- Using a `BufWriter` in `print_json_text` gives another speedup. Writing formatted JSON to a file is now ~25 times faster than before.
- Writing to a redirect or a file now doesn't stream unless you use `--stream`, like HTTPie, and it properly decodes the response when it needs to.