### PR TITLE
Do not require filenames to be valid unicode

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt,
     io::{self, stdout, Stdout, Write},
+    path::Path,
 };
 
 use termcolor::{Ansi, ColorChoice, StandardStream, WriteColor};
@@ -20,7 +21,7 @@ pub enum Buffer {
 impl Buffer {
     pub fn new(
         download: bool,
-        output: &Option<String>,
+        output: Option<&Path>,
         is_stdout_tty: bool,
         pretty: Option<Pretty>,
     ) -> io::Result<Self> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,8 +82,8 @@ pub struct Cli {
     pub stream: bool,
 
     /// Save output to FILE instead of stdout.
-    #[structopt(short = "o", long, value_name = "FILE")]
-    pub output: Option<String>,
+    #[structopt(short = "o", long, value_name = "FILE", parse(from_os_str))]
+    pub output: Option<PathBuf>,
 
     /// Download the body to a file instead of printing it.
     #[structopt(short = "d", long)]
@@ -161,14 +161,14 @@ pub struct Cli {
     pub verify: Option<Verify>,
 
     /// Use a client side certificate for SSL.
-    #[structopt(long, value_name = "FILE")]
+    #[structopt(long, value_name = "FILE", parse(from_os_str))]
     pub cert: Option<PathBuf>,
 
     /// A private key file to use with --cert.
     ///
     /// Only necessary if the private key is not contained in the cert file.
     /// {n}{n}{n}
-    #[structopt(long, value_name = "FILE")]
+    #[structopt(long, value_name = "FILE", parse(from_os_str))]
     pub cert_key: Option<PathBuf>,
 
     /// The default scheme to use if not specified in the URL.
@@ -275,7 +275,7 @@ const NEGATION_FLAGS: &[&str] = &[
 
 impl Cli {
     pub fn from_args() -> Self {
-        Cli::from_iter(std::env::args())
+        Cli::from_iter(std::env::args_os())
     }
 
     pub fn from_iter<I>(iter: I) -> Self

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ fn main() -> Result<i32> {
 
     let buffer = Buffer::new(
         args.download,
-        &args.output,
+        args.output.as_deref(),
         atty::is(Stream::Stdout) || test_pretend_term(),
         args.pretty,
     )?;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -404,7 +404,8 @@ mod tests {
 
     fn run_cmd(args: impl IntoIterator<Item = String>, is_stdout_tty: bool) -> Printer {
         let args = Cli::from_iter_safe(args).unwrap();
-        let buffer = Buffer::new(args.download, &args.output, is_stdout_tty, None).unwrap();
+        let buffer =
+            Buffer::new(args.download, args.output.as_deref(), is_stdout_tty, None).unwrap();
         let pretty = args.pretty.unwrap_or_else(|| buffer.guess_pretty());
         Printer::new(pretty, args.style, false, buffer)
     }

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -143,6 +143,7 @@ pub fn translate(args: Cli) -> Result<Command> {
         cmd.push(num.to_string());
     }
     if let Some(filename) = args.output {
+        let filename = filename.to_str().ok_or_else(|| anyhow!("Invalid UTF-8"))?;
         cmd.flag("-o", "--output");
         cmd.push(filename);
     } else if args.download {


### PR DESCRIPTION
`xh -o $'\xaa' example.org` currently panics. This changes it so that it just works.