### PR TITLE
Improve progress bar formatting

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -67,7 +67,13 @@ impl Buffer {
         } else if test_pretend_term() {
             Pretty::format
         } else if self.is_terminal() {
-            Pretty::all
+            // supports_color() considers $TERM, $NO_COLOR, etc
+            // This lets us do the right thing with the progress bar
+            if self.supports_color() {
+                Pretty::all
+            } else {
+                Pretty::format
+            }
         } else {
             Pretty::none
         }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -69,7 +69,7 @@ impl Buffer {
         } else if self.is_terminal() {
             // supports_color() considers $TERM, $NO_COLOR, etc
             // This lets us do the right thing with the progress bar
-            if self.supports_color() {
+            if self.supports_color() || cfg!(test) {
                 Pretty::all
             } else {
                 Pretty::format

--- a/src/download.rs
+++ b/src/download.rs
@@ -147,12 +147,13 @@ fn total_for_content_range(header: &str, expected_start: u64) -> Result<u64> {
 }
 
 const BAR_TEMPLATE: &str =
-    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes} {bytes_per_sec} ETA {eta}";
+    "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes} {bytes_per_sec} ETA {eta}";
 const UNCOLORED_BAR_TEMPLATE: &str =
-    "{spinner} [{elapsed_precise}] [{bar:40}] {bytes} {bytes_per_sec} ETA {eta}";
-const SPINNER_TEMPLATE: &str = "{spinner:.green} [{elapsed_precise}] {bytes} {bytes_per_sec} {msg}";
+    "{spinner} [{elapsed_precise}] [{wide_bar}] {bytes} {bytes_per_sec} ETA {eta}";
+const SPINNER_TEMPLATE: &str =
+    "{spinner:.green} [{elapsed_precise}] {bytes} {bytes_per_sec} {wide_msg}";
 const UNCOLORED_SPINNER_TEMPLATE: &str =
-    "{spinner} [{elapsed_precise}] {bytes} {bytes_per_sec} {msg}";
+    "{spinner} [{elapsed_precise}] {bytes} {bytes_per_sec} {wide_msg}";
 
 pub fn download_file(
     mut response: Response,


### PR DESCRIPTION
- Prevent mitsuhiko/indicatif#144 in narrow terminals
- Keep bar coloring consistent with other colored output (e.g. don't color it if `$NO_COLOR` is set)