### PR TITLE
Use adaptive window for HTTP/2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "async-compression",
  "base64",

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ xh -d httpbin.org/json -o res.json
 
 - Not all of HTTPie's features are implemented. ([#4](https://github.com/ducaale/xh/issues/4))
 - HTTP/2 cannot be disabled. ([#68](https://github.com/ducaale/xh/issues/68))
-- Large downloads over HTTP/2 are currently slow. ([#49](https://github.com/ducaale/xh/issues/49))
 - No plugin system.
 - General immaturity. HTTPie is old and well-tested.
 - Worse documentation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,9 @@ fn main() -> Result<i32> {
         false => Policy::none(),
     };
 
-    let mut client = Client::builder().redirect(redirect);
+    let mut client = Client::builder()
+        .http2_adaptive_window(true)
+        .redirect(redirect);
     let mut resume: Option<u64> = None;
 
     if url.scheme() == "https" {


### PR DESCRIPTION
Resolves #49.

Earlier I said:

> Enabling `http2_adaptive_window` raises the max speed (in my test, 15 MB/s vs wget's 18 MB/s), but it causes the speed to ramp up much more slowly initially. I'm not sure why. `http2_initial_stream_window_size()` and `http2_initial_connection_window_size()` don't seem to help.

This time I didn't see the slow ramp-up. My best guess is that it happened before because I was testing on a cheap VPS with a pretty fast connection but otherwise very low specs. I think this is an improvement on net.