### PR TITLE
Add Brotli to Accept-Encoding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,10 @@ fn main() -> Result<i32> {
     let request = {
         let mut request_builder = client
             .request(method, url.clone())
-            .header(ACCEPT_ENCODING, HeaderValue::from_static("gzip, deflate"))
+            .header(
+                ACCEPT_ENCODING,
+                HeaderValue::from_static("gzip, deflate, br"),
+            )
             .header(CONNECTION, HeaderValue::from_static("keep-alive"))
             .header(USER_AGENT, get_user_agent());
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -196,7 +196,7 @@ fn verbose() {
         .stdout(indoc! {r#"
         POST / HTTP/1.1
         accept: application/json, */*;q=0.5
-        accept-encoding: gzip, deflate
+        accept-encoding: gzip, deflate, br
         connection: keep-alive
         content-length: 9
         content-type: application/json


### PR DESCRIPTION
`br` (Brotli) isn't defined in `Accept-Encoding`, I think `Content-Encoding` doesn't returns `br`, so fix this.