### PR TITLE
Replace HTTP/2 adaptive window by fixed window to prevent crashes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,8 @@ fn main() -> Result<i32> {
     };
 
     let mut client = Client::builder()
-        .http2_adaptive_window(true)
+        .http2_initial_stream_window_size(4_194_304)
+        .http2_initial_connection_window_size(4_194_304)
         .timeout(timeout)
         .redirect(redirect);
 


### PR DESCRIPTION
The HTTP/2 adaptive window feature sends a lot of pings. Cloudflare doesn't like that and eventually breaks off the connection.

We can just set a large initial window instead. A window of 4 MiB appears to give the same speed (tested on Linux with a local HTTP/2 server and an artificial delay).

This way we also reach maximum speed earlier, the adaptive window takes a while to grow.

I'm unsure how this affects memory usage, particularly on Windows, which doesn't overcommit memory.

Resolves #135.