### PR TITLE
Fix a bug where same file cannot be re-downloaded

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -88,8 +88,11 @@ fn open_new_file(file_name: PathBuf) -> io::Result<(PathBuf, File)> {
         return Ok((file_name, file));
     }
     for suffix in 1..u32::MAX {
-        let mut candidate = file_name.clone();
-        candidate.push(format!("-{}", suffix));
+        let candidate = {
+            let mut candidate = file_name.clone().into_os_string();
+            candidate.push(format!("-{}", suffix));
+            PathBuf::from(candidate)
+        };
         if let Some(file) = try_open_new(&candidate)? {
             return Ok((candidate, file));
         }


### PR DESCRIPTION
### Before

```
$ xh httpbin.org/json -d
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-origin: *
connection: keep-alive
content-length: 429
content-type: application/json
date: Sat, 08 May 2021 13:39:04 GMT
server: gunicorn/19.9.0

Downloading 429B to "json.json"
Done. 429B in less than a second

$ xh httpbin.org/json -d
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-origin: *
connection: keep-alive
content-length: 429
content-type: application/json
date: Sat, 08 May 2021 13:39:06 GMT
server: gunicorn/19.9.0

Error: Not a directory (os error 20)
```

### After
```
$ xh httpbin.org/json -d
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-origin: *
connection: keep-alive
content-length: 429
content-type: application/json
date: Sat, 08 May 2021 14:16:51 GMT
server: gunicorn/19.9.0

Downloading 429B to "json.json"
Done. 429B in less than a second

$ xh httpbin.org/json -d
HTTP/1.1 200 OK
access-control-allow-credentials: true
access-control-allow-origin: *
connection: keep-alive
content-length: 429
content-type: application/json
date: Sat, 08 May 2021 14:16:52 GMT
server: gunicorn/19.9.0

Downloading 429B to "json.json-1"
Done. 429B in less than a second
````