### PR TITLE
Enforce accept-encoding to identity in download mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -144,16 +144,10 @@ fn main() -> Result<i32> {
 
     let client = client.build()?;
 
-    let compression_scheme = if args.download {
-        HeaderValue::from_static("identity")
-    } else {
-        HeaderValue::from_static("gzip, br")
-    };
-
     let mut request = {
         let mut request_builder = client
             .request(method, url.clone())
-            .header(ACCEPT_ENCODING, compression_scheme)
+            .header(ACCEPT_ENCODING, HeaderValue::from_static("gzip, br"))
             .header(CONNECTION, HeaderValue::from_static("keep-alive"))
             .header(USER_AGENT, get_user_agent());
 
@@ -225,6 +219,12 @@ fn main() -> Result<i32> {
         });
 
         request
+    };
+
+    if args.download {
+        request
+            .headers_mut()
+            .insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
     };
 
     let buffer = Buffer::new(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1230,3 +1230,21 @@ fn json_field_from_file() {
         .assert();
     mock.assert();
 }
+
+#[test]
+fn accept_encoding_not_modifiable_in_download_mode() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.header("accept-encoding", "identity");
+        then.body(r#"{"ids":[1,2,3]}"#);
+    });
+
+    let dir = tempdir().unwrap();
+    get_command()
+        .current_dir(&dir)
+        .arg(server.base_url())
+        .arg("--download")
+        .arg("accept-encoding:gzip")
+        .assert();
+    mock.assert();
+}


### PR DESCRIPTION
HTTPie behaviour is to ignore `accept-encoding` altogether in download mode.

Also, see https://httpie.io/docs#other-notes