### PR TITLE
Support {REQUESTS, CURL}_CA_BUNDLE env variables

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -385,6 +385,14 @@ impl Cli {
             cli.https = true;
         }
 
+        if cli.verify.is_none() {
+            if let Some(path) = env::var_os("REQUESTS_CA_BUNDLE") {
+                cli.verify = Some(Verify::CustomCaBundle(PathBuf::from(path)));
+            } else if let Some(path) = env::var_os("CURL_CA_BUNDLE") {
+                cli.verify = Some(Verify::CustomCaBundle(PathBuf::from(path)));
+            }
+        }
+
         cli.process_relations()?;
         Ok(cli)
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -385,14 +385,6 @@ impl Cli {
             cli.https = true;
         }
 
-        if cli.verify.is_none() {
-            if let Some(path) = env::var_os("REQUESTS_CA_BUNDLE") {
-                cli.verify = Some(Verify::CustomCaBundle(PathBuf::from(path)));
-            } else if let Some(path) = env::var_os("CURL_CA_BUNDLE") {
-                cli.verify = Some(Verify::CustomCaBundle(PathBuf::from(path)));
-            }
-        }
-
         cli.process_relations()?;
         Ok(cli)
     }


### PR DESCRIPTION
This PR adds support for HTTPie's undocumented `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` environment variables that behave similarly to the `--verify PATH` flag.

See https://github.com/ducaale/xh/issues/4#issuecomment-827942103