### PR TITLE
Support installation by Huber

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | sh
 | OS             | Method    | Command                 |
 |----------------|-----------|-------------------------|
 | Any            | Cargo\*   | `cargo install xh`      |
+| Any            | [Huber]   | `huber install xh`      |
 | Arch Linux     | Pacman    | `pacman -S xh`          |
 | Linux & macOS  | Nixpkgs   | `nix-env -iA nixpkgs.xh`|
 | Linux & macOS  | Homebrew  | `brew install xh`       |
@@ -26,6 +27,9 @@ curl -sfL https://raw.githubusercontent.com/ducaale/xh/master/install.sh | sh
 | Windows        | Scoop     | `scoop install xh`      |
 
 \* Make sure that you have Rust 1.46 or later installed
+
+[Huber]: https://github.com/innobead/huber#installing-huber
+
 
 ### via pre-built binaries
 The [release page](https://github.com/ducaale/xh/releases) contains prebuilt binaries for Linux, macOS and Windows.


### PR DESCRIPTION
Huber is a package manager for Github Repo Releases, and `xh` can be managed by Huber.

```console
❯ huber search xh
 Name  Description                                       Source 
 xh    Friendly and fast tool for sending HTTP requests  https://github.com/ducaale/xh 
❯ huber install xh
Installed executables:
 - /home/davidko/.huber/bin/xh
xh (version: v0.10.0, source: github) installed
❯ xh -V
xh 0.10.0
```

ref: https://github.com/innobead/huber