### PR TITLE
Do not hardcode /tmp in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ fi
 
 echo "Downloading xh..."
 
-temp_dir=$(mktemp -d /tmp/xh.XXXXXXXX)
+temp_dir=$(mktemp -dt xh.XXXXXX)
 trap 'rm -rf "$temp_dir"' EXIT INT TERM
 cd "$temp_dir"
 


### PR DESCRIPTION
Some systems don't have `/tmp` at that location.

Additionally, `XXXXXX` is the maximum number of Xes that busybox's `mktemp` replaces, so I reduced it to that.

Tested on Debian, Alpine, and [Termux](https://termux.com/). I think it works on macOS, but [its `-t` flag works differently](https://ss64.com/osx/mktemp.html), so it should be tested there too.

(This is not enough to get xh itself working in Termux on my phone, because of dynamic linking. Maybe we should switch to `arm-unknown-linux-musleabihf`, a binary for that target does run. But even then the DNS is broken.)