### PR TITLE
Beautify help messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -2123,6 +2124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2158,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_urlencoded = "0.7.0"
 shell-escape = "0.1.5"
-structopt = "0.3"
+structopt = { version = "0.3", features = ["wrap_help"] }
 termcolor = "1.1.2"
 jsonxf = "1.1.0"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,11 @@ use crate::{buffer::Buffer, request_items::RequestItem};
 ///
 /// It reimplements as much as possible of HTTPie's excellent design.
 #[derive(StructOpt, Debug)]
-#[structopt(name = "xh", settings = &[AppSettings::DeriveDisplayOrder, AppSettings::UnifiedHelpMessage])]
+#[structopt(
+    name = "xh",
+    settings = &[AppSettings::DeriveDisplayOrder, AppSettings::UnifiedHelpMessage],
+    global_setting = AppSettings::ColoredHelp,
+)]
 pub struct Cli {
     /// (default) Serialize data items from the command line as a JSON object.
     #[structopt(short = "j", long, overrides_with_all = &["form", "multipart"])]


### PR DESCRIPTION
1. Add `wrap_help` feature to clap
2. Enable `AppSettings::ColoredHelp`

Before:

![image](https://user-images.githubusercontent.com/70888415/120861704-4a88cb80-c5ba-11eb-945c-90ef6ec9ab59.png)

After:

![image](https://user-images.githubusercontent.com/70888415/120861710-4eb4e900-c5ba-11eb-97d2-e63efe0c7338.png)
