### PR TITLE
Enable check-status by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ xh httpbin.org/get  # resolves to http://httpbin.org/get
 xhs httpbin.org/get # resolves to https://httpbin.org/get
 ```
 
+### Strict compatibility mode
+
+TODO: explain how renaming binary to either `http` or `https` turns on strict compatibility mode.
+
 ## Examples
 
 ```sh
@@ -161,11 +165,12 @@ xh -d httpbin.org/json -o res.json
 
 ### Other differences
 
+- `--check-status` is enabled unless `xh` is being used in
+  [strict compatibility mode](https://github.com/ducaale/xh#strict-compatibility-mode).
 - `rustls` is used instead of the system's TLS library.
 - Headers are sent and printed in lowercase.
 - JSON keys are not sorted.
 - Formatted output is always UTF-8.
-- `--check-status` is enabled by default.
 
 ## Similar or related Projects
 

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ xh -d httpbin.org/json -o res.json
 
 - [curlie](https://github.com/rs/curlie) - frontend to cURL that adds the ease of use of httpie
 - [httpie-go](https://github.com/nojima/httpie-go) - httpie-like HTTP client written in Go
-- [curl2httpie](https://github.com/dcb9/curl2httpie) - covert command arguments between cURL and HTTPie
+- [curl2httpie](https://github.com/dcb9/curl2httpie) - convert command arguments between cURL and HTTPie

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ xhs httpbin.org/get # resolves to https://httpbin.org/get
 
 ### Strict compatibility mode
 
-This can be useful for users who are initially migrating from HTTPie to `xh`. To enable this mode, you can either
-rename the binary to `http`/`https` or use `XH_HTTPIE_COMPAT_MODE` env variable.
+If `xh` is invoked as `http` or `https` (by renaming the binary), or if the `XH_HTTPIE_COMPAT_MODE` environment variable is set,
+it will run in HTTPie compatibility mode. The only current difference is that `--check-status` is not enabled by default.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ xhs httpbin.org/get # resolves to https://httpbin.org/get
 
 ### Strict compatibility mode
 
-TODO: explain how renaming binary to either `http` or `https` turns on strict compatibility mode.
+This can be useful for users who are initially migrating from HTTPie to `xh`. To enable this mode, you can either
+rename the binary to `http`/`https` or use `XH_HTTPIE_COMPAT_MODE` env variable.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ xh -d httpbin.org/json -o res.json
 - Headers are sent and printed in lowercase.
 - JSON keys are not sorted.
 - Formatted output is always UTF-8.
+- `--check-status` is enabled by default.
 
 ## Similar or related Projects
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,9 @@ use crate::{buffer::Buffer, request_items::RequestItem};
     ],
 )]
 pub struct Cli {
+    #[structopt(skip)]
+    pub strict_compat_mode: bool,
+
     /// (default) Serialize data items from the command line as a JSON object.
     #[structopt(short = "j", long, overrides_with_all = &["form", "multipart"])]
     pub json: bool,
@@ -388,11 +391,12 @@ impl Cli {
             cli.request_items.push(request_item.parse()?);
         }
 
-        if matches!(
-            app.get_bin_name().and_then(|name| name.split('.').next()),
-            Some("https") | Some("xhs") | Some("xhttps")
-        ) {
+        let bin_name = app.get_bin_name().and_then(|name| name.split('.').next());
+        if matches!(bin_name, Some("https") | Some("xhs") | Some("xhttps")) {
             cli.https = true;
+        }
+        if matches!(bin_name, Some("http") | Some("https")) {
+            cli.strict_compat_mode = true;
         }
 
         cli.process_relations(&matches)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -431,6 +431,9 @@ impl Cli {
             (false, true) => Some(false),
             (false, false) => None,
         };
+        if self.download {
+            self.check_status = Some(true);
+        }
         // `overrides_with_all` ensures that only one of these is true
         if self.json {
             // Also the default, so this shouldn't do anything

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ use crate::{buffer::Buffer, request_items::RequestItem};
 )]
 pub struct Cli {
     #[structopt(skip)]
-    pub strict_compat_mode: bool,
+    pub httpie_compat_mode: bool,
 
     /// (default) Serialize data items from the command line as a JSON object.
     #[structopt(short = "j", long, overrides_with_all = &["form", "multipart"])]
@@ -395,8 +395,10 @@ impl Cli {
         if matches!(bin_name, Some("https") | Some("xhs") | Some("xhttps")) {
             cli.https = true;
         }
-        if matches!(bin_name, Some("http") | Some("https")) {
-            cli.strict_compat_mode = true;
+        if matches!(bin_name, Some("http") | Some("https"))
+            || env::var_os("XH_HTTPIE_COMPAT_MODE").is_some()
+        {
+            cli.httpie_compat_mode = true;
         }
 
         cli.process_relations(&matches)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,7 @@ fn main() -> Result<i32> {
             printer.print_response_headers(&response)?;
         }
         let status = response.status();
-        let check_status = args.check_status.unwrap_or(!args.strict_compat_mode);
+        let check_status = args.check_status.unwrap_or(!args.httpie_compat_mode);
         let exit_code: i32 = match status.as_u16() {
             _ if !(check_status) => 0,
             300..=399 if !args.follow => 3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn main() -> Result<i32> {
         }
         let status = response.status();
         let exit_code: i32 = match status.as_u16() {
-            _ if !(args.check_status || args.download) => 0,
+            _ if !(args.check_status.unwrap_or(true) || args.download) => 0,
             300..=399 if !args.follow => 3,
             400..=499 => 4,
             500..=599 => 5,

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,8 +274,9 @@ fn main() -> Result<i32> {
             printer.print_response_headers(&response)?;
         }
         let status = response.status();
+        let check_status = args.check_status.unwrap_or(!args.strict_compat_mode);
         let exit_code: i32 = match status.as_u16() {
-            _ if !(args.check_status.unwrap_or(true)) => 0,
+            _ if !(check_status) => 0,
             300..=399 if !args.follow => 3,
             400..=499 => 4,
             500..=599 => 5,

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn main() -> Result<i32> {
         }
         let status = response.status();
         let exit_code: i32 = match status.as_u16() {
-            _ if !(args.check_status.unwrap_or(true) || args.download) => 0,
+            _ if !(args.check_status.unwrap_or(true)) => 0,
             300..=399 if !args.follow => 3,
             400..=499 => 4,
             500..=599 => 5,

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -129,7 +129,9 @@ pub fn translate(args: Cli) -> Result<Command> {
         // showing up right away
         cmd.flag("-N", "--no-buffer");
     }
-    if args.check_status {
+    // Since --fail is bit disruptive than HTTPie's --check-status flag, we will not enable
+    // it unless the user explicitely sets the latter flag
+    if args.check_status.unwrap_or(false) {
         // Suppresses output on failure, unlike us
         cmd.flag("-f", "--fail");
     }

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -420,18 +420,18 @@ mod tests {
             ),
             (
                 "xh -d httpbin.org/get",
-                "curl -L -O 'http://httpbin.org/get'",
-                "curl -L -O http://httpbin.org/get",
+                "curl -f -L -O 'http://httpbin.org/get'",
+                "curl -f -L -O http://httpbin.org/get",
             ),
             (
                 "xh -d -o foobar --continue httpbin.org/get",
-                "curl -L -o foobar -C - 'http://httpbin.org/get'",
-                "curl -L -o foobar -C - http://httpbin.org/get",
+                "curl -f -L -o foobar -C - 'http://httpbin.org/get'",
+                "curl -f -L -o foobar -C - http://httpbin.org/get",
             ),
             (
                 "xh --curl-long -d -o foobar --continue httpbin.org/get",
-                "curl --location --output foobar --continue-at - 'http://httpbin.org/get'",
-                "curl --location --output foobar --continue-at - http://httpbin.org/get",
+                "curl --fail --location --output foobar --continue-at - 'http://httpbin.org/get'",
+                "curl --fail --location --output foobar --continue-at - http://httpbin.org/get",
             ),
             (
                 "xh httpbin.org/post @foo.txt",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -624,6 +624,36 @@ fn check_status() {
 }
 
 #[test]
+fn check_status_is_implied() {
+    let server = MockServer::start();
+    let mock = server.mock(|_when, then| {
+        then.status(404);
+    });
+
+    get_command()
+        .arg(server.base_url())
+        .assert()
+        .code(4)
+        .stderr("");
+    mock.assert();
+}
+
+#[test]
+fn check_status_is_not_implied_in_compat_mode() {
+    let server = MockServer::start();
+    let mock = server.mock(|_when, then| {
+        then.status(404);
+    });
+
+    get_command()
+        .env("XH_HTTPIE_COMPAT_MODE", "")
+        .arg(server.base_url())
+        .assert()
+        .code(0);
+    mock.assert();
+}
+
+#[test]
 fn user_password_auth() {
     let server = MockServer::start();
     let mock = server.mock(|when, _then| {


### PR DESCRIPTION
- [x] Introduce strict compatibility mode
- [x] Enable `--check-status` by default if strict compatibility mode is not on.

Resolves https://github.com/ducaale/xh/issues/144