### PR TITLE
Replace static curl with vendored openssl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,6 @@ jobs:
           - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
             use-cross: true
-            flags: --no-default-features # Integration tests don't work with cross
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
           - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
             use-cross: true
-            flags: --no-default-features # Integration tests don't work with cross
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1372,20 @@ checksum = "ed063c96cf4c0f2e5d09324409d158b38a0a85a7b90fbd68c8cad75c495d5775"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
 ]
 
 [[package]]
@@ -2572,7 +2601,6 @@ dependencies = [
  "assert_cmd",
  "assert_matches",
  "atty",
- "curl",
  "dirs 3.0.2",
  "encoding_rs",
  "encoding_rs_io",
@@ -2588,6 +2616,7 @@ dependencies = [
  "mime2ext",
  "mime_guess",
  "netrc-rs",
+ "openssl",
  "pem",
  "predicates",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,19 +47,13 @@ default-features = false
 features = ["parsing", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 
 [dev-dependencies]
-# Some are only needed for the `integration-tests` feature, but dev-dependencies can't be optional
 assert_cmd = "1.0"
 assert_matches = "1.4.0"
 indoc = "1.0"
 predicates = "1.0.7"
 httpmock = "0.5.5"
-curl = { version = "0.4.34", features = ["static-ssl"] }
+openssl = { version = "0.10", features = ["vendored"] }
 tempfile = "3.2.0"
-
-[features]
-default = ["integration-tests"]
-
-integration-tests = []
 
 [build-dependencies]
 syntect = { version = "4.4", default-features = false }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "integration-tests")]
 use std::{
     fs::File,
     fs::{read_to_string, OpenOptions},


### PR DESCRIPTION
This is another attempt at making integration tests work everywhere. Also see the following:
* https://stackoverflow.com/a/65990512/5915221
* https://github.com/rust-embedded/cross/issues/229#issuecomment-597898074