### PR TITLE
Mark automated releases as draft

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,5 +97,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
             files: 'xh*'
+            draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This can come in handy when a release fails for some targets but not for others. Draft releases should also allow us to add more information to the release before it starts notifying everyone who starred the project 😬.