### PR TITLE
[nit] initialize raw_url directly from match arm

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -428,19 +428,18 @@ impl Cli {
             _ => {}
         }
         let mut rest_args = mem::take(&mut cli.raw_rest_args).into_iter();
-        let raw_url;
-        match parse_method(&cli.raw_method_or_url) {
+        let raw_url = match parse_method(&cli.raw_method_or_url) {
             Some(method) => {
                 cli.method = Some(method);
-                raw_url = rest_args.next().ok_or_else(|| {
+                rest_args.next().ok_or_else(|| {
                     Error::with_description("Missing URL", ErrorKind::MissingArgumentOrSubcommand)
-                })?;
+                })?
             }
             None => {
                 cli.method = None;
-                raw_url = mem::take(&mut cli.raw_method_or_url);
+                mem::take(&mut cli.raw_method_or_url)
             }
-        }
+        };
         for request_item in rest_args {
             cli.request_items.items.push(request_item.parse()?);
         }


### PR DESCRIPTION
Hello, I'm interested in issue #178, `--raw` option. If there is no one working on it, may I do this?

I looked up the related issues and pull request in [httpie](https://github.com/httpie/httpie) and it seems I can implement `--raw` option in xh.

While reading the code, I refactor a very little part. :D