### PR TITLE
Do not rebuild when no files changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,10 +35,11 @@ fn main() {
     for dir in &["assets", "assets/basic", "assets/large"] {
         println!("cargo:rerun-if-changed={}", dir);
         for entry in read_dir(dir).unwrap() {
-            println!(
-                "cargo:rerun-if-changed={}",
-                entry.unwrap().path().to_str().unwrap()
-            );
+            let path = entry.unwrap().path();
+            let path = path.to_str().unwrap();
+            if path.ends_with(".sublime-syntax") || path.ends_with(".tmTheme") {
+                println!("cargo:rerun-if-changed={}", path);
+            }
         }
     }
 


### PR DESCRIPTION
We were asking cargo to rebuild if `assets/xhs` or `assets/xhs.1.gz` changed. Those are dead symlinks, so cargo always errors and [assumes they changed](https://github.com/rust-lang/cargo/blob/e475fe4a1780dafb771b39cddf8097ec206b0028/src/cargo/core/compiler/fingerprint.rs#L1733).

That caused a lot of unnecessary rebuilds. I found the problem by running with `CARGO_LOG=cargo::core::compiler::fingerprint=info`.

Asking cargo to watch only the files we actually care about fixes it.