### PR TITLE
Allow Setting the User Agent For Requests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,6 +292,10 @@ pub struct Cli {
     #[structopt(value_name = "[METHOD] URL")]
     raw_method_or_url: String,
 
+    /// The user agent to make the request with.
+    #[structopt(long, short = "u")]
+    pub user_agent: Option<String>,
+
     /// Optional key-value pairs to be included in the request
     ///
     ///   - key==value to add a parameter to the URL

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,10 @@ fn run(args: Cli) -> Result<i32> {
                 ACCEPT_ENCODING,
                 HeaderValue::from_static("gzip, deflate, br"),
             )
-            .header(USER_AGENT, get_user_agent());
+            .header(
+                USER_AGENT,
+                args.user_agent.unwrap_or(get_user_agent().to_string()),
+            );
 
         if matches!(
             args.http_version,


### PR DESCRIPTION
Hey there! I've been using `xh` for random requests and I had the need to set the user agent for a request I was making. Here's a PR that let's you do that with either the `-u` or `--user-agent` flag. Let me know if there's anything I need to fix!