### PR TITLE
Do not print response body unconditionally

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -500,7 +500,7 @@ fn run(args: Cli) -> Result<i32> {
                     args.quiet,
                 )?;
             }
-        } else {
+        } else if print.response_body {
             printer.print_response_body(response, response_charset, response_mime)?;
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2520,3 +2520,23 @@ fn override_response_mime() {
         "#});
     mock.assert();
 }
+
+#[test]
+fn omit_response_body() {
+    let server = MockServer::start();
+    let mock = server.mock(|_when, then| {
+        then.header("date", "N/A").body("Hello!");
+    });
+
+    get_command()
+        .arg("--print=h")
+        .arg(server.base_url())
+        .assert()
+        .stdout(indoc! {r#"
+            HTTP/1.1 200 OK
+            Content-Length: 6
+            Date: N/A
+
+        "#});
+    mock.assert();
+}


### PR DESCRIPTION
I'm surprised no tests caught this. It might be worth a bugfix release.