### PR TITLE
Add browser-style text encoding detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chardetng"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ee29c16b81c32fbc882ecc568305793338a8353952573db837f4f4a6cd5c2e"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,9 +393,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if",
 ]
@@ -2160,6 +2171,7 @@ dependencies = [
  "assert_cmd",
  "assert_matches",
  "atty",
+ "chardetng",
  "cookie",
  "cookie_store",
  "digest_auth",
@@ -2172,6 +2184,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "jsonxf",
+ "memchr",
  "mime",
  "mime2ext",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["assets/xhs", "assets/xhs.1.gz"]
 [dependencies]
 anyhow = "1.0.38"
 atty = "0.2"
+chardetng = "0.1.15"
 cookie_crate = { version = "0.15", package = "cookie" }
 cookie_store = { version = "0.15.0" }
 digest_auth = "0.3.0"
@@ -23,6 +24,7 @@ encoding_rs_io = "0.1.7"
 humantime = "2.1.0"
 indicatif = "0.16.2"
 jsonxf = "1.1.0"
+memchr = "2.4.1"
 mime = "0.3.16"
 mime2ext = "0.1.0"
 mime_guess = "2.0"


### PR DESCRIPTION
- If there's no explicit encoding it's detected using [chardetng](https://github.com/hsivonen/chardetng), which was made for Firefox.
- HTML is never assumed to be UTF-8, that has to be declared explicitly. This is a bit iffy, it'll definitely break some real world output. But it's consistent with how browsers handle it. See https://hsivonen.fi/utf-8-detection/.
  One argument against this is that fetch and XHR can assume UTF-8 even if loading as a normal webpage can't. What do you think?
- BOM sniffing is no longer used when the encoding is explicit.
- Streaming and non-streaming decodes now behave the same when it comes to encoding detection and BOM handling.

I had to do a bunch of research for this one, I hope it's not too hard to follow.