### PR TITLE
Add aarch64 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,10 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             use-cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            use-cross: true
+            flags: -- --test-threads=4
           - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
             use-cross: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,10 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             use-cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            use-cross: true
+            flags: -- --test-threads=4
           - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
             use-cross: true
@@ -49,7 +53,12 @@ jobs:
       matrix:
         job:
           - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            binutils: aarch64-linux-gnu
+            use-cross: true
+          - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
+            binutils: arm-linux-gnueabihf
             use-cross: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
@@ -72,9 +81,9 @@ jobs:
       - name: Strip release binary (linux and macOS)
         if: matrix.job.os != 'windows-latest'
         run: |
-          if [ "${{ matrix.job.target }}" = "arm-unknown-linux-gnueabihf" ]; then
-            sudo apt-get -y install gcc-arm-linux-gnueabihf
-            arm-linux-gnueabihf-strip "target/${{ matrix.job.target }}/release/xh"
+          if [ "${{ matrix.job.binutils }}" != "" ]; then
+            sudo apt -y install "binutils-${{ matrix.job.binutils }}"
+            "${{ matrix.job.binutils }}-strip" "target/${{ matrix.job.target }}/release/xh"
           else
             strip "target/${{ matrix.job.target }}/release/xh"
           fi

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,9 @@ if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
     target="x86_64-apple-darwin"
 elif [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]; then
     target="x86_64-unknown-linux-musl"
-elif [ "$(uname -s)" = "Linux" ] && ( uname -m | grep -q -e '^arm' -e '^aarch' ); then
+elif [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "aarch64" ]; then
+    target="aarch64-unknown-linux-musl"
+elif [ "$(uname -s)" = "Linux" ] && ( uname -m | grep -q -e '^arm' ); then
     target="arm-unknown-linux-gnueabihf"
 else
     echo "Unsupported OS or architecture"


### PR DESCRIPTION
Discussed in #212.

~Still trying to figure why tests are failing with multiple errors. It's not clear which file or directory wasn't found.~

~Was able to reproduce it locally with `cross test --target aarch64-unknown-linux-gnu`. Interestingly enough, switching to `aarch64-unknown-linux-musl` works.~

Edit: fixed switching to the expected `aarch64-unknown-linux-musl`.