### PR TITLE
Statically link C-runtime for MSVC Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,16 +69,21 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             flags: --features=native-tls
+            rustflags: -C target-feature=+crt-static
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set RUSTFLAGS env variable
+        if: matrix.job.rustflags
+        shell: bash
+        run: echo "RUSTFLAGS=${{ matrix.job.rustflags }}" >> $GITHUB_ENV
+
       - name: Build target
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
           args: --release --target ${{ matrix.job.target }} ${{ matrix.job.flags }}
-        env:
-          RUSTFLAGS: ${{ matrix.job.os == 'windows-latest' && '-C target-feature=+crt-static' || '' }}
 
       - name: Strip release binary (linux and macOS)
         if: matrix.job.os != 'windows-latest'
@@ -92,6 +97,7 @@ jobs:
 
       - id: get_version
         uses: battila7/get-version-action@v2
+
       - name: Package
         shell: bash
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,8 @@ jobs:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
           args: --release --target ${{ matrix.job.target }} ${{ matrix.job.flags }}
+        env:
+          RUSTFLAGS: ${{ matrix.job.os == 'windows-latest' && '-C target-feature=+crt-static' || '' }}
 
       - name: Strip release binary (linux and macOS)
         if: matrix.job.os != 'windows-latest'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,8 @@ jobs:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
           args: --release --target ${{ matrix.job.target }} ${{ matrix.job.flags }}
+        env:
+          CARGO_PROFILE_RELEASE_LTO: true
 
       - name: Strip release binary (linux and macOS)
         if: matrix.job.os != 'windows-latest'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,3 @@ xh is a friendly and fast tool for sending HTTP requests.
 It reimplements as much as possible of HTTPie's excellent design, with a focus
 on improved performance.
 """
-
-[profile.release]
-lto = true

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+    "CARGO_PROFILE_RELEASE_LTO",
+]


### PR DESCRIPTION
On windows, xh requires `VS C++ Runtime Redistributable` to be installed or will fail with `The code execution cannot proceed because VCRUNTIME140.dll was not found`. This PR changes that by statically linking the C-runtime.

Also, see https://github.com/BurntSushi/ripgrep/pull/1613

Partially resolves #219