### PR TITLE
Enable using OS certificate store with rustls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/.direnv
+/.envrc
 /target
 /.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1382,6 +1383,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ url = "2.2.2"
 [dependencies.reqwest]
 version = "0.11.6"
 default-features = false
-features = ["rustls-tls", "json", "gzip", "brotli", "deflate", "multipart", "blocking", "socks", "cookies"]
+features = ["rustls-tls", "rustls-tls-webpki-roots", "rustls-tls-native-roots", "json", "gzip", "brotli", "deflate", "multipart", "blocking", "socks", "cookies"]
 
 [dependencies.syntect]
 version = "4.4"


### PR DESCRIPTION
Closes https://github.com/ducaale/xh/issues/224.

I ran `cargo update` since I didn't know the command to just update the lockfile after changing `Cargo.toml`, but it worked and created no additional test failures so I've left that. If you want the smaller set of `Cargo.lock` changes let me know.

Two tests fail, but they also fail for me on master:
- `basic_auth_from_session_is_used`
- `bearer_auth_from_session_is_used`

Is there any additional setup required for the tests?