### PR TITLE
Highlight text line by line instead of all at once

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -4,6 +4,7 @@ use syntect::dumps::from_binary;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
+use syntect::util::LinesWithEndings;
 use termcolor::WriteColor;
 
 use crate::{buffer::Buffer, cli::Theme};
@@ -53,10 +54,12 @@ impl<'a> Highlighter<'a> {
     }
 
     /// Write a single piece of highlighted text.
-    pub fn highlight(&mut self, line: &str) -> io::Result<()> {
-        for (style, component) in self.highlighter.highlight(line, self.syntax_set) {
-            self.out.set_color(&convert_style(style))?;
-            write!(self.out, "{}", component)?;
+    pub fn highlight(&mut self, text: &str) -> io::Result<()> {
+        for line in LinesWithEndings::from(text) {
+            for (style, component) in self.highlighter.highlight(line, self.syntax_set) {
+                self.out.set_color(&convert_style(style))?;
+                write!(self.out, "{}", component)?;
+            }
         }
         Ok(())
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -95,13 +95,6 @@ impl Printer {
     }
 
     fn print_colorized_text(&mut self, text: &str, syntax: &'static str) -> io::Result<()> {
-        // This could perhaps be optimized
-        // syntect processes the whole buffer at once, doing it line by line might
-        // let us start printing earlier (but can decrease quality since regexes
-        // can't look ahead)
-        // A buffered writer could improve performance, but we'd have to use a
-        // BufferedStandardStream instead of a StandardStream, which is slightly tricky
-        // (wrapping a BufWriter around a Buffer wouldn't preserve syntax coloring)
         self.get_highlighter(syntax).highlight(text)
     }
 

--- a/src/request_items.rs
+++ b/src/request_items.rs
@@ -132,10 +132,7 @@ impl FromStr for RequestItem {
             // item
             Err(clap::Error::raw(
                 clap::ErrorKind::InvalidValue,
-                format!(
-                    "Invalid value for '[REQUEST_ITEM]...': {:?}",
-                    request_item
-                ),
+                format!("Invalid value for '[REQUEST_ITEM]...': {:?}", request_item),
             ))
         }
     }


### PR DESCRIPTION
A while ago I changed it to highlight the full body at once, but that can actually be a lot slower.

For example, fetching a local copy of [this page](https://docs.rs/syntect/latest/syntect/easy/struct.HighlightLines.html) goes from 200ms to 100ms after this change.