### PR TITLE
Switch to full buffering and manual flushing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-compression"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,7 +2153,6 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "assert_matches",
  "atty",
  "chardetng",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ features = ["parsing", "html", "yaml-load", "dump-load", "dump-create", "regex-o
 
 [dev-dependencies]
 assert_cmd = "2.0"
-assert_matches = "1.4.0"
 form_urlencoded = "1.0.1"
 indoc = "1.0"
 predicates = "1.0.7"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,59 +1,302 @@
+//! The [`Buffer`] type is responsible for writing the program output, be it
+//! to a terminal or a pipe or a file. It supports colored output using
+//! `termcolor`'s `WriteColor` trait.
+//!
+//! It's always buffered, so `.flush()` should be called whenever no new
+//! output is immediately available. That's inconvenient, but improves
+//! throughput.
+//!
+//! We want slightly different implementations depending on the platform and
+//! the runtime conditions. Ansi<BufWriter> is fast, so we go through that
+//! when possible, but on Windows we often need a BufferedStandardStream
+//! instead to use the terminal APIs.
+//!
+//! Most of this code is boilerplate.
+
 use std::{
-    fmt,
-    io::{self, stdout, LineWriter, Stdout, Write},
+    env::var_os,
+    io::{self, Write},
     path::Path,
 };
-
-use termcolor::{Ansi, ColorChoice, StandardStream, WriteColor};
 
 use crate::{
     cli::Pretty,
     utils::{test_default_color, test_pretend_term},
 };
 
-pub enum Buffer {
-    // These are all line-buffered (File explicitly, the others implicitly)
-    // Line buffering gives unsurprising behavior but can still be a lot
-    // faster than no buffering, especially with lots of small writes from
-    // coloring
-    File(Ansi<LineWriter<std::fs::File>>),
-    Redirect(Ansi<Stdout>),
-    Stdout(StandardStream),
-    Stderr(StandardStream),
+pub use imp::Buffer;
+
+#[cfg(not(windows))]
+mod imp {
+    use std::io::{BufWriter, Write};
+
+    use termcolor::{Ansi, WriteColor};
+
+    pub struct Buffer {
+        inner: Ansi<BufWriter<Inner>>,
+        terminal: bool,
+        redirect: bool,
+    }
+
+    enum Inner {
+        File(std::fs::File),
+        Stdout(std::io::Stdout),
+        Stderr(std::io::Stderr),
+    }
+
+    impl Buffer {
+        pub fn stdout() -> Self {
+            Self {
+                inner: Ansi::new(BufWriter::new(Inner::Stdout(std::io::stdout()))),
+                terminal: true,
+                redirect: false,
+            }
+        }
+
+        pub fn stderr() -> Self {
+            Self {
+                inner: Ansi::new(BufWriter::new(Inner::Stderr(std::io::stderr()))),
+                terminal: true,
+                redirect: false,
+            }
+        }
+
+        pub fn redirect() -> Self {
+            Self {
+                inner: Ansi::new(BufWriter::new(Inner::Stdout(std::io::stdout()))),
+                terminal: crate::test_pretend_term(),
+                redirect: true,
+            }
+        }
+
+        pub fn file(file: std::fs::File) -> Self {
+            Self {
+                inner: Ansi::new(BufWriter::new(Inner::File(file))),
+                terminal: false,
+                redirect: false,
+            }
+        }
+
+        pub fn is_terminal(&self) -> bool {
+            self.terminal
+        }
+
+        pub fn is_redirect(&self) -> bool {
+            self.redirect
+        }
+
+        #[cfg(test)]
+        pub fn is_stdout(&self) -> bool {
+            matches!(self.inner.get_ref().get_ref(), Inner::Stdout(_))
+        }
+
+        #[cfg(test)]
+        pub fn is_stderr(&self) -> bool {
+            matches!(self.inner.get_ref().get_ref(), Inner::Stderr(_))
+        }
+
+        #[cfg(test)]
+        pub fn is_file(&self) -> bool {
+            matches!(self.inner.get_ref().get_ref(), Inner::File(_))
+        }
+    }
+
+    impl Write for Inner {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            match self {
+                Inner::File(w) => w.write(buf),
+                Inner::Stdout(w) => w.write(buf),
+                Inner::Stderr(w) => w.write(buf),
+            }
+        }
+
+        fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+            match self {
+                Inner::File(w) => w.write_all(buf),
+                Inner::Stdout(w) => w.write_all(buf),
+                Inner::Stderr(w) => w.write_all(buf),
+            }
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            match self {
+                Inner::File(w) => w.flush(),
+                Inner::Stdout(w) => w.flush(),
+                Inner::Stderr(w) => w.flush(),
+            }
+        }
+    }
+
+    impl Write for Buffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.inner.write(buf)
+        }
+
+        fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+            // get_mut() to directly write into the BufWriter is significantly faster
+            // https://github.com/BurntSushi/termcolor/pull/56
+            self.inner.get_mut().write_all(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.inner.flush()
+        }
+    }
+
+    impl WriteColor for Buffer {
+        fn supports_color(&self) -> bool {
+            true
+        }
+
+        fn set_color(&mut self, spec: &termcolor::ColorSpec) -> std::io::Result<()> {
+            self.inner.set_color(spec)
+        }
+
+        fn reset(&mut self) -> std::io::Result<()> {
+            self.inner.reset()
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::io::{BufWriter, Write};
+
+    use termcolor::{Ansi, BufferedStandardStream, ColorChoice, WriteColor};
+
+    use crate::utils::test_default_color;
+
+    pub enum Buffer {
+        // Only escape codes make sense when the output isn't going directly
+        // to a terminal, so we use Ansi for some cases.
+        File(Ansi<BufWriter<std::fs::File>>),
+        Redirect(Ansi<BufWriter<std::io::Stdout>>),
+        Stdout(BufferedStandardStream),
+        Stderr(BufferedStandardStream),
+    }
+
+    impl Buffer {
+        pub fn stdout() -> Self {
+            Buffer::Stdout(BufferedStandardStream::stdout(if test_default_color() {
+                ColorChoice::AlwaysAnsi
+            } else {
+                ColorChoice::Always
+            }))
+        }
+
+        pub fn stderr() -> Self {
+            Buffer::Stderr(BufferedStandardStream::stderr(if test_default_color() {
+                ColorChoice::AlwaysAnsi
+            } else {
+                ColorChoice::Always
+            }))
+        }
+
+        pub fn redirect() -> Self {
+            Buffer::Redirect(Ansi::new(BufWriter::new(std::io::stdout())))
+        }
+
+        pub fn file(file: std::fs::File) -> Self {
+            Buffer::File(Ansi::new(BufWriter::new(file)))
+        }
+
+        pub fn is_terminal(&self) -> bool {
+            matches!(self, Buffer::Stdout(_) | Buffer::Stderr(_))
+        }
+
+        pub fn is_redirect(&self) -> bool {
+            matches!(self, Buffer::Redirect(_))
+        }
+
+        #[cfg(test)]
+        pub fn is_stdout(&self) -> bool {
+            matches!(self, Buffer::Stdout(_))
+        }
+
+        #[cfg(test)]
+        pub fn is_stderr(&self) -> bool {
+            matches!(self, Buffer::Stderr(_))
+        }
+
+        #[cfg(test)]
+        pub fn is_file(&self) -> bool {
+            matches!(self, Buffer::File(_))
+        }
+    }
+
+    impl Write for Buffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            match self {
+                Buffer::File(w) => w.write(buf),
+                Buffer::Redirect(w) => w.write(buf),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.write(buf),
+            }
+        }
+
+        fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+            match self {
+                Buffer::File(w) => w.get_mut().write_all(buf),
+                Buffer::Redirect(w) => w.get_mut().write_all(buf),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.write_all(buf),
+            }
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            match self {
+                Buffer::File(w) => w.flush(),
+                Buffer::Redirect(w) => w.flush(),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.flush(),
+            }
+        }
+    }
+
+    impl WriteColor for Buffer {
+        fn supports_color(&self) -> bool {
+            match self {
+                Buffer::File(w) => w.supports_color(),
+                Buffer::Redirect(w) => w.supports_color(),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.supports_color(),
+            }
+        }
+
+        fn set_color(&mut self, spec: &termcolor::ColorSpec) -> std::io::Result<()> {
+            match self {
+                Buffer::File(w) => w.set_color(spec),
+                Buffer::Redirect(w) => w.set_color(spec),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.set_color(spec),
+            }
+        }
+
+        fn reset(&mut self) -> std::io::Result<()> {
+            match self {
+                Buffer::File(w) => w.reset(),
+                Buffer::Redirect(w) => w.reset(),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.reset(),
+            }
+        }
+
+        fn is_synchronous(&self) -> bool {
+            match self {
+                Buffer::File(w) => w.is_synchronous(),
+                Buffer::Redirect(w) => w.is_synchronous(),
+                Buffer::Stdout(w) | Buffer::Stderr(w) => w.is_synchronous(),
+            }
+        }
+    }
 }
 
 impl Buffer {
-    pub fn new(
-        download: bool,
-        output: Option<&Path>,
-        is_stdout_tty: bool,
-        pretty: Option<Pretty>,
-    ) -> io::Result<Self> {
-        let color_choice = match pretty {
-            None if test_default_color() => ColorChoice::AlwaysAnsi,
-            None => ColorChoice::Auto,
-            Some(pretty) if pretty.color() => ColorChoice::Always,
-            Some(..) => ColorChoice::Never,
-        };
+    pub fn new(download: bool, output: Option<&Path>, is_stdout_tty: bool) -> io::Result<Self> {
         Ok(if download {
-            Buffer::Stderr(StandardStream::stderr(color_choice))
+            Buffer::stderr()
         } else if let Some(output) = output {
-            let file = std::fs::File::create(&output)?;
-            Buffer::File(Ansi::new(LineWriter::new(file)))
+            let file = std::fs::File::create(output)?;
+            Buffer::file(file)
         } else if is_stdout_tty {
-            Buffer::Stdout(StandardStream::stdout(color_choice))
+            Buffer::stdout()
         } else {
-            Buffer::Redirect(Ansi::new(stdout()))
+            Buffer::redirect()
         })
-    }
-
-    pub fn is_terminal(&self) -> bool {
-        matches!(self, Buffer::Stdout(..) | Buffer::Stderr(..))
-            || (matches!(self, Buffer::Redirect(..)) && test_pretend_term())
-    }
-
-    pub fn is_redirect(&self) -> bool {
-        matches!(self, Buffer::Redirect(..))
     }
 
     pub fn print(&mut self, s: impl AsRef<[u8]>) -> io::Result<()> {
@@ -66,83 +309,21 @@ impl Buffer {
         } else if test_pretend_term() {
             Pretty::format
         } else if self.is_terminal() {
-            // supports_color() considers $TERM, $NO_COLOR, etc
-            // This lets us do the right thing with the progress bar
-            if self.supports_color() || cfg!(test) {
+            // Based on termcolor's logic for ColorChoice::Auto
+            if cfg!(test) {
                 Pretty::all
-            } else {
+            } else if var_os("NO_COLOR").is_some() {
                 Pretty::format
+            } else {
+                match var_os("TERM") {
+                    Some(term) if term == "dumb" => Pretty::format,
+                    Some(_) => Pretty::all,
+                    None if cfg!(windows) => Pretty::all,
+                    None => Pretty::format,
+                }
             }
         } else {
             Pretty::none
         }
-    }
-
-    fn inner(&self) -> &dyn WriteColor {
-        match self {
-            Buffer::File(file) => file,
-            Buffer::Stdout(stream) | Buffer::Stderr(stream) => stream,
-            Buffer::Redirect(stream) => stream,
-        }
-    }
-
-    fn inner_mut(&mut self) -> &mut dyn WriteColor {
-        match self {
-            Buffer::File(file) => file,
-            Buffer::Stdout(stream) | Buffer::Stderr(stream) => stream,
-            Buffer::Redirect(stream) => stream,
-        }
-    }
-}
-
-impl Write for Buffer {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self {
-            Buffer::File(file) => file.write(buf),
-            Buffer::Stdout(stream) | Buffer::Stderr(stream) => stream.write(buf),
-            Buffer::Redirect(stream) => stream.write(buf),
-        }
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner_mut().flush()
-    }
-}
-
-impl WriteColor for Buffer {
-    fn supports_color(&self) -> bool {
-        self.inner().supports_color()
-    }
-
-    fn set_color(&mut self, spec: &termcolor::ColorSpec) -> io::Result<()> {
-        // We should only even attempt highlighting if coloring is supported
-        debug_assert!(self.supports_color());
-        // This one's called often, so avoid the overhead of dyn
-        match self {
-            Buffer::File(file) => file.set_color(spec),
-            Buffer::Stdout(stream) | Buffer::Stderr(stream) => stream.set_color(spec),
-            Buffer::Redirect(stream) => stream.set_color(spec),
-        }
-    }
-
-    fn reset(&mut self) -> io::Result<()> {
-        self.inner_mut().reset()
-    }
-
-    fn is_synchronous(&self) -> bool {
-        self.inner().is_synchronous()
-    }
-}
-
-// Cannot be derived because StandardStream doesn't implement it
-impl fmt::Debug for Buffer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let text = match self {
-            Buffer::File(..) => "File",
-            Buffer::Stderr(..) => "Stderr",
-            Buffer::Stdout(..) => "Stdout",
-            Buffer::Redirect(..) => "Redirect",
-        };
-        write!(f, "{}(..)", text)
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -245,7 +245,7 @@ pub fn download_file(
 
     match pb {
         Some(ref pb) => {
-            copy_largebuf(&mut pb.wrap_read(response), &mut buffer)?;
+            copy_largebuf(&mut pb.wrap_read(response), &mut buffer, false)?;
             let downloaded_length = pb.position() - starting_length;
             pb.finish_and_clear();
             let time_taken = starting_time.elapsed();
@@ -261,7 +261,7 @@ pub fn download_file(
             }
         }
         None => {
-            copy_largebuf(&mut response, &mut buffer)?;
+            copy_largebuf(&mut response, &mut buffer, false)?;
         }
     }
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -67,6 +67,10 @@ impl<'a> Highlighter<'a> {
     pub fn highlight_bytes(&mut self, line: &[u8]) -> io::Result<()> {
         self.highlight(&String::from_utf8_lossy(line))
     }
+
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.out.flush()
+    }
 }
 
 impl Drop for Highlighter<'_> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,7 +439,6 @@ fn run(args: Cli) -> Result<i32> {
         args.download,
         args.output.as_deref(),
         atty::is(Stream::Stdout) || test_pretend_term(),
-        args.pretty,
     )?;
     let is_output_redirected = buffer.is_redirect();
     let print = match args.print {


### PR DESCRIPTION
All output is now fully buffered. That means it might not show up
until `.flush()` is called, so `.flush()` has to be called manually
pretty frequently. The general rule is that it should be called when
the next output might not be ready yet. For example, `.flush()` is
called at the end of `print_request_body()`, so the request is visible
before waiting for the response.

This gets trickiest for streaming responses. They have to flush after
receiving the next piece of response from the server, but not more
often than that (or it'd hurt performance). `BinaryGuard` and
`copy_largebuf` have been changed to make that possible.

But these are also where the greatest gains are made: A (piped)
`--stream --pretty format` JSON response is now ten times as
fast as before. That's admittedly a bit niche, but I think `--stream`
might now always be faster than not streaming. (I haven't benchmarked
it exhaustively yet.)

The `Buffer` type is overhauled, in part for unrelated
optimization. It turns out that it can matter a lot which specific
types from `termcolor` are used.