### PR TITLE
Update clap to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -228,18 +228,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d044e9db8cd0f68191becdeb5246b7462e4cf0c069b19ae00d1bf3fa9889498d"
+checksum = "23eec4dd324308f49d8bf86a2732078c34d57955fec1e1d865554fc37c15d420"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["assets/xhs", "assets/xhs.1.gz"]
 anyhow = "1.0.38"
 atty = "0.2"
 chardetng = "0.1.15"
-clap = { version = "3.0.0", features = ["derive", "wrap_help"] }
-clap_complete = "3.0.0"
+clap = { version = "3.1.0", features = ["derive", "wrap_help"] }
+clap_complete = "3.1.0"
 cookie_crate = { version = "0.15", package = "cookie" }
 cookie_store = { version = "0.15.0" }
 digest_auth = "0.3.0"

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn build_syntax(dir: &str, out: &str) {
 fn feature_status(feature: &str) -> String {
     if env::var_os(format!(
         "CARGO_FEATURE_{}",
-        feature.to_uppercase().replace("-", "_")
+        feature.to_uppercase().replace('-', "_")
     ))
     .is_some()
     {

--- a/completions/_xh.ps1
+++ b/completions/_xh.ps1
@@ -12,7 +12,8 @@ Register-ArgumentCompleter -Native -CommandName 'xh' -ScriptBlock {
             $element = $commandElements[$i]
             if ($element -isnot [StringConstantExpressionAst] -or
                 $element.StringConstantType -ne [StringConstantType]::BareWord -or
-                $element.Value.StartsWith('-')) {
+                $element.Value.StartsWith('-') -or
+                $element.Value -eq $wordToComplete) {
                 break
         }
         $element.Value

--- a/generate.sh
+++ b/generate.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 
 XH_HELP2MAN=1 help2man \
   --include 'doc/man-template.roff' \
-  --help-option 'help' \
+  --help-option '--help' \
   --version-option '-V' \
   --name 'Friendly and fast tool for sending HTTP requests' \
   --output 'doc/xh.1' \


### PR DESCRIPTION
- Deal with the deprecations
- Remove the `error.info` hack
- Fix a clippy warning that's showing up on nightly