### PR TITLE
Apply some lints of `clippy::pedantic` and `clippy::nursery`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs::read_dir;
 use std::path::Path;
 
-use syntect::dumps::*;
+use syntect::dumps::dump_to_file;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSetBuilder;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1360,7 +1360,7 @@ mod tests {
         ];
 
         for (input, output) in test_cases {
-            assert_eq!(parse_encoding(input).unwrap(), output)
+            assert_eq!(parse_encoding(input).unwrap(), output);
         }
 
         assert_eq!(parse_encoding("notreal").is_err(), true);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1021,7 +1021,7 @@ mod tests {
         Cli::try_parse_from(
             Some("xh".to_string())
                 .into_iter()
-                .chain(args.iter().map(|s| s.to_string())),
+                .chain(args.iter().map(ToString::to_string)),
         )
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -829,7 +829,7 @@ pub struct Timeout(Duration);
 
 impl Timeout {
     pub fn as_duration(&self) -> Option<Duration> {
-        Some(self.0).filter(|t| t != &Duration::from_nanos(0))
+        Some(self.0).filter(|t| !t.is_zero())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,9 +422,9 @@ fn run(args: Cli) -> Result<i32> {
 
         let mut request = request_builder.headers(headers).build()?;
 
-        headers_to_unset.iter().for_each(|h| {
-            request.headers_mut().remove(h);
-        });
+        for header in &headers_to_unset {
+            request.headers_mut().remove(header);
+        }
 
         request
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ fn run(args: Cli) -> Result<i32> {
             if args.native_tls {
                 // Unlike the --verify case this is advertised to not work, so it's
                 // not an outright bug, but it's still imaginable that it'll start working
-                warn("Client certificates are not supported for native-tls")
+                warn("Client certificates are not supported for native-tls");
             }
 
             let mut buffer = Vec::new();

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -41,7 +41,7 @@ pub trait Middleware {
 
     fn print(&self, ctx: &mut Context, response: Response, request: &mut Request) -> Result<()> {
         if let Some(ref mut printer) = ctx.printer {
-            printer(response, request)?
+            printer(response, request)?;
         }
 
         Ok(())

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use encoding_rs::Encoding;
 use encoding_rs_io::DecodeReaderBytesBuilder;
 use mime::Mime;
-use reqwest::blocking::{Request, Response};
+use reqwest::blocking::{Body, Request, Response};
 use reqwest::cookie::CookieStore;
 use reqwest::header::{
     HeaderMap, HeaderName, HeaderValue, ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HOST,
@@ -359,7 +359,7 @@ impl Printer {
         // See https://github.com/seanmonstar/reqwest/issues/1030
         // reqwest and hyper add certain headers, but only in the process of
         // sending the request, which we haven't done yet
-        if let Some(body) = request.body().and_then(|body| body.as_bytes()) {
+        if let Some(body) = request.body().and_then(Body::as_bytes) {
             // Added at https://github.com/seanmonstar/reqwest/blob/e56bd160ba/src/blocking/request.rs#L132
             headers
                 .entry(CONTENT_LENGTH)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -427,7 +427,7 @@ impl Printer {
         encoding: Option<&'static Encoding>,
         mime: Option<&str>,
     ) -> anyhow::Result<()> {
-        let url = response.url().to_owned();
+        let url = response.url().clone();
         let content_type = mime
             .map(ContentType::from)
             .unwrap_or_else(|| get_content_type(response.headers()));

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -428,9 +428,8 @@ impl Printer {
         mime: Option<&str>,
     ) -> anyhow::Result<()> {
         let url = response.url().clone();
-        let content_type = mime
-            .map(ContentType::from)
-            .unwrap_or_else(|| get_content_type(response.headers()));
+        let content_type =
+            mime.map_or_else(|| get_content_type(response.headers()), ContentType::from);
         let encoding = encoding.or_else(|| get_charset(&response));
 
         if !self.buffer.is_terminal() {
@@ -547,8 +546,7 @@ pub fn get_content_type(headers: &HeaderMap) -> ContentType {
     headers
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .map(ContentType::from)
-        .unwrap_or(ContentType::Unknown)
+        .map_or(ContentType::Unknown, ContentType::from)
 }
 
 pub fn valid_json(text: &str) -> bool {

--- a/src/session.rs
+++ b/src/session.rs
@@ -168,7 +168,7 @@ impl Session {
 
     pub fn cookies(&self) -> Vec<cookie_crate::Cookie> {
         let mut cookies = vec![];
-        for (name, c) in self.content.cookies.iter() {
+        for (name, c) in &self.content.cookies {
             let mut cookie_builder = cookie_crate::Cookie::build(name, &c.value);
             if let Some(expires) = c.expires {
                 cookie_builder =

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,6 +132,6 @@ pub fn copy_largebuf(
     }
 }
 
-pub(crate) fn url_requires_native_tls(url: &Url) -> bool {
+pub fn url_requires_native_tls(url: &Url) -> bool {
     url.scheme() == "https" && matches!(url.host(), Some(Host::Ipv4(..)) | Some(Host::Ipv6(..)))
 }

--- a/src/vendored/reqwest_cookie_store.rs
+++ b/src/vendored/reqwest_cookie_store.rs
@@ -21,7 +21,7 @@ fn set_cookies(
         std::str::from_utf8(val.as_bytes())
             .map_err(RawCookieParseError::from)
             .and_then(RawCookie::parse)
-            .map(|c| c.into_owned())
+            .map(RawCookie::into_owned)
             .ok()
     });
     cookie_store.store_response_cookies(cookies, url);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2052,8 +2052,8 @@ fn expired_cookies_are_removed_from_session() {
 }
 
 fn cookies_are_equal(c1: &str, c2: &str) -> bool {
-    HashSet::<_>::from_iter(c1.split(';').map(|c| c.trim()))
-        == HashSet::<_>::from_iter(c2.split(';').map(|c| c.trim()))
+    HashSet::<_>::from_iter(c1.split(';').map(str::trim))
+        == HashSet::<_>::from_iter(c2.split(';').map(str::trim))
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -818,7 +818,7 @@ fn netrc_env_user_password_auth() {
 
 #[test]
 fn netrc_file_user_password_auth() {
-    for netrc_file in [".netrc", "_netrc"].iter() {
+    for netrc_file in &[".netrc", "_netrc"] {
         let server = server::http(|req| async move {
             assert_eq!(req.headers()["Authorization"], "Basic dXNlcjpwYXNz");
             hyper::Response::default()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1993,7 +1993,7 @@ fn expired_cookies_are_removed_from_session() {
         .unwrap()
         .as_secs()
         + 1000;
-    let past_timestamp = 1114425967; // 2005-04-25
+    let past_timestamp = 1_114_425_967; // 2005-04-25
 
     let session_file = NamedTempFile::new().unwrap();
 


### PR DESCRIPTION
Apply the following:

- [`clippy::explicit_iter_loop`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#explicit_iter_loop)
- [`clippy::implicit_clone`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#implicit_clone)
- [`clippy::map_unwrap_or`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#map_unwrap_or)
- [`clippy::needless_for_each`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#needless_for_each)
- [`clippy::redundant_closure_for_method_calls`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#redundant_closure_for_method_calls)
- [`clippy::redundant_pub_crate`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#redundant_pub_crate)
- [`clippy::semicolon_if_nothing_returned`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#semicolon_if_nothing_returned)
- [`clippy::unreadable_literal`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#unreadable_literal)
- [`clippy::wildcard_imports`](https://rust-lang.github.io/rust-clippy/rust-1.59.0/index.html#wildcard_imports)