### PR TITLE
Support sending multiple request headers with the same key

### DIFF
--- a/src/request_items.rs
+++ b/src/request_items.rs
@@ -269,7 +269,7 @@ impl RequestItems {
                     let key = HeaderName::from_bytes(key.as_bytes())?;
                     let value = HeaderValue::from_str(value)?;
                     headers_to_unset.remove(&key);
-                    headers.insert(key, value);
+                    headers.append(key, value);
                 }
                 RequestItem::HttpHeaderToUnset(key) => {
                     let key = HeaderName::from_bytes(key.as_bytes())?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -215,6 +215,20 @@ fn header() {
 }
 
 #[test]
+fn multiple_headers_with_same_key() {
+    let server = server::http(|req| async move {
+        let mut hello_header = req.headers().get_all("hello").iter();
+        assert_eq!(hello_header.next().unwrap(), &"world");
+        assert_eq!(hello_header.next().unwrap(), &"people");
+        hyper::Response::default()
+    });
+    get_command()
+        .args(&[&server.base_url(), "hello:world", "hello:people"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn query_param() {
     let server = server::http(|req| async move {
         assert_eq!(req.query_params()["foo"], "bar");


### PR DESCRIPTION
This PR doesn't address how these headers will be saved in a sessions file because we would need to change the structure of the session file and HTTPie hasn't addressed that yet.