### PR TITLE
Cache build artifacts in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,8 @@ jobs:
           target: ${{ matrix.job.target }}
           override: true
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.job.target }}
       - uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
           toolchain: 1.54.0 # minimum supported rust version
           target: ${{ matrix.job.target }}
           override: true
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}
@@ -60,6 +61,8 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Rustfmt
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
See https://www.reillywood.com/blog/rust-faster-ci/

**Edit**: This seems to work best for builds that are not using rust-cross. I think the reason is that dependencies are still recompiled when using rust-cross.


| job | [before](https://github.com/ducaale/xh/actions/runs/2253525224) | [after](https://github.com/ducaale/xh/actions/runs/2253546021) |
|-----|---------|------|
| Rustfmt and Clippy | 3min 2s | 21s |
| x86_64-unknown-linux-gnu | 3m 38s | 50s |
| x86_64-apple-darwin | 4min 50s | 1m 20s |
| x86_64-pc-windows-msvc | 7m 3s | 2m 7s |
| x86_64-unknown-linux-musl | 5m 23s | 3m 56s |
| aarch64-unknown-linux-musl | 5m 49s | 4min 35s |
| arm-unknown-linux-gnueabihf | 7m 2s | 5min 50s |

**Edit 2**: The issue in rust-cross was that target was not taken to account. This meant that jobs that used the same os but different targets were sharing the same cache. Now that target is part of the cache key, rust-cross jobs are fast as well.
