### PR TITLE
Add optional install-dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,9 +59,25 @@ case $PATH in
         ;;
 esac
 
-printf "Install location [default: %s]: " "$default_bin"
-read -r bindir < /dev/tty
-bindir=${bindir:-$default_bin}
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case "$key" in
+        --install-dir)
+            install_dir="$2"
+            shift
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$install_dir" ]]; then
+    printf "Install location [default: %s]: " "$default_bin"
+    read -r bindir < /dev/tty
+    bindir=${bindir:-$default_bin}
+else
+    bindir=${install_dir}
+fi
 
 while ! test -d "$bindir"; do
     echo "Directory $bindir does not exist"

--- a/install.sh
+++ b/install.sh
@@ -59,31 +59,33 @@ case $PATH in
         ;;
 esac
 
-_read_bindir() {
+_read_installdir() {
     printf "Install location [default: %s]: " "$default_bin"
-    read -r XH_BINDIR < /dev/tty
-    XH_BINDIR=${XH_BINDIR:-$default_bin}
+    read -r xh_installdir < /dev/tty
+    xh_installdir=${xh_installdir:-$default_bin}
 }
 
 if [ -z "$XH_BINDIR" ]; then
-    _read_bindir
+    _read_installdir
 
-    while ! test -d "$XH_BINDIR"; do
-      echo "Directory $XH_BINDIR does not exist"
-      _read_bindir
+    while ! test -d "$xh_installdir"; do
+        echo "Directory $xh_installdir does not exist"
+        _read_installdir
     done
+else
+    xh_installdir=${XH_BINDIR}
 fi
 
 tar xzf xh.tar.gz
 
-if test -w "$XH_BINDIR"; then
-    mv xh-*/xh "$XH_BINDIR/"
-    ln -sf "$XH_BINDIR/xh" "$XH_BINDIR/xhs"
+if test -w "$xh_installdir" || [ -n "$XH_BINDIR" ]; then
+    mv xh-*/xh "$xh_installdir/"
+    ln -sf "$xh_installdir/xh" "$xh_installdir/xhs"
 else
-    sudo mv xh-*/xh "$XH_BINDIR/"
-    sudo ln -sf "$XH_BINDIR/xh" "$XH_BINDIR/xhs"
+    sudo mv xh-*/xh "$xh_installdir/"
+    sudo ln -sf "$xh_installdir/xh" "$xh_installdir/xhs"
 fi
 
-echo "$("$XH_BINDIR"/xh -V) has been installed to:"
-echo " • $XH_BINDIR/xh"
-echo " • $XH_BINDIR/xhs"
+echo "$("$xh_installdir"/xh -V) has been installed to:"
+echo " • $xh_installdir/xh"
+echo " • $xh_installdir/xhs"

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ case $PATH in
         ;;
 esac
 
-while [[ $# -gt 0 ]]
+while [ $# -gt 0 ]
 do
     key="$1"
     case "$key" in
@@ -68,34 +68,38 @@ do
             shift
             shift
             ;;
+        *)
+            echo "Unknown option ${key}"
+            exit 1
+            ;;
     esac
 done
 
-if [[ -z "$install_dir" ]]; then
+if [ -z "$install_dir" ]; then
     printf "Install location [default: %s]: " "$default_bin"
-    read -r bindir < /dev/tty
-    bindir=${bindir:-$default_bin}
-else
-    bindir=${install_dir}
-fi
+    read -r XH_BINDIR < /dev/tty
+    XH_BINDIR=${XH_BINDIR:-$default_bin}
 
-while ! test -d "$bindir"; do
-    echo "Directory $bindir does not exist"
-    printf "Install location [default: %s]: " "$default_bin"
-    read -r bindir < /dev/tty
-    bindir=${bindir:-$default_bin}
-done
+    while ! test -d "$XH_BINDIR"; do
+      echo "Directory $XH_BINDIR does not exist"
+      printf "Install location [default: %s]: " "$default_bin"
+      read -r XH_BINDIR < /dev/tty
+      XH_BINDIR=${XH_BINDIR:-$default_bin}
+    done
+else
+    XH_BINDIR=${install_dir}
+fi
 
 tar xzf xh.tar.gz
 
-if test -w "$bindir"; then
-    mv xh-*/xh "$bindir/"
-    ln -sf "$bindir/xh" "$bindir/xhs"
+if test -w "$XH_BINDIR"; then
+    mv xh-*/xh "$XH_BINDIR/"
+    ln -sf "$XH_BINDIR/xh" "$XH_BINDIR/xhs"
 else
-    sudo mv xh-*/xh "$bindir/"
-    sudo ln -sf "$bindir/xh" "$bindir/xhs"
+    sudo mv xh-*/xh "$XH_BINDIR/"
+    sudo ln -sf "$XH_BINDIR/xh" "$XH_BINDIR/xhs"
 fi
 
-echo "$("$bindir"/xh -V) has been installed to:"
-echo " • $bindir/xh"
-echo " • $bindir/xhs"
+echo "$("$XH_BINDIR"/xh -V) has been installed to:"
+echo " • $XH_BINDIR/xh"
+echo " • $XH_BINDIR/xhs"

--- a/install.sh
+++ b/install.sh
@@ -59,35 +59,19 @@ case $PATH in
         ;;
 esac
 
-while [ $# -gt 0 ]
-do
-    key="$1"
-    case "$key" in
-        --install-dir)
-            install_dir="$2"
-            shift
-            shift
-            ;;
-        *)
-            echo "Unknown option ${key}"
-            exit 1
-            ;;
-    esac
-done
-
-if [ -z "$install_dir" ]; then
+_read_bindir() {
     printf "Install location [default: %s]: " "$default_bin"
     read -r XH_BINDIR < /dev/tty
     XH_BINDIR=${XH_BINDIR:-$default_bin}
+}
+
+if [ -z "$XH_BINDIR" ]; then
+    _read_bindir
 
     while ! test -d "$XH_BINDIR"; do
       echo "Directory $XH_BINDIR does not exist"
-      printf "Install location [default: %s]: " "$default_bin"
-      read -r XH_BINDIR < /dev/tty
-      XH_BINDIR=${XH_BINDIR:-$default_bin}
+      _read_bindir
     done
-else
-    XH_BINDIR=${install_dir}
 fi
 
 tar xzf xh.tar.gz


### PR DESCRIPTION
Thanks a lot for this!

This adds a ability to specify an install dir when using the `install.sh` script. I use the script to install via automation on Fedora and it waiting for input is a bit of an issue. This could be a non-intrusive/breaking way for allowing an install dir?