### PR TITLE
Add some exit status

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,13 +84,15 @@ fn main() {
                 eprintln!();
                 eprintln!("Try running without the --native-tls flag.");
             }
-            if msg == "operation timed out" {
-                process::exit(2);
-            } else if msg.starts_with("Too many redirects") {
-                process::exit(6);
-            } else {
-                process::exit(1);
+            if let Some(err) = err.downcast_ref::<reqwest::Error>() {
+                if err.is_timeout() {
+                    process::exit(2);
+                }
             }
+            if msg.starts_with("Too many redirects") {
+                process::exit(6);
+            }
+            process::exit(1);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,13 @@ fn main() {
                 eprintln!();
                 eprintln!("Try running without the --native-tls flag.");
             }
-            process::exit(1);
+            if msg == "operation timed out" {
+                process::exit(2);
+            } else if msg.starts_with("Too many redirects") {
+                process::exit(6);
+            } else {
+                process::exit(1);
+            }
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -544,7 +544,7 @@ fn timeout() {
     get_command()
         .args(&["--timeout=0.1", &server.base_url()])
         .assert()
-        .failure()
+        .code(2)
         .stderr(contains("operation timed out"));
 }
 
@@ -2370,7 +2370,7 @@ fn max_redirects_is_enforced() {
         .args(&[&server.base_url(), "--follow", "--max-redirects=5"])
         .assert()
         .stderr(contains("Too many redirects (--max-redirects=5)"))
-        .failure();
+        .code(6);
 }
 
 #[test]


### PR DESCRIPTION
The exit status will be 2 when the request timed out, and the exit status will be 6 when the redirect exceeds `--max-redirects <NUM>`. This is the same behavior as HTTPie.

ref: <https://httpie.io/docs/cli/scripting>