### PR TITLE
Move cross config from `Cross.toml` to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ default = ["online-tests"]
 online-tests = []
 native-tls = ["reqwest/native-tls", "reqwest/native-tls-alpn"]
 
+[package.metadata.cross.build.env]
+passthrough = ["CARGO_PROFILE_RELEASE_LTO"]
+
 [package.metadata.deb]
 features = []
 section = "web"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,0 @@
-[build.env]
-passthrough = [
-    "CARGO_PROFILE_RELEASE_LTO",
-]


### PR DESCRIPTION
The recently released [cross-rs v0.2.2](https://github.com/cross-rs/cross/releases/tag/v0.2.2) can read configuration from `Cargo.toml` metadata which allows us to get rid of `Cross.toml` in the top-level directory.

Note that `ci.yaml` is still using v0.2.1 due to cached build artifacts but that shouldn't happen in `release.yaml`.