### PR TITLE
Support cross runner with multiple arguments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
         with:
-          key: ${{ matrix.job.target }}
+          key: v2-${{ matrix.job.target }}
       - uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.job.use-cross }}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -76,7 +76,11 @@ fn get_base_command() -> Command {
     let mut cmd;
     let path = assert_cmd::cargo::cargo_bin("xh");
     if let Some(runner) = find_runner() {
-        cmd = Command::new(runner);
+        let mut runner = runner.split_whitespace();
+        cmd = Command::new(runner.next().unwrap());
+        while let Some(arg) = runner.next() {
+            cmd.arg(arg);
+        }
         cmd.arg(path);
     } else {
         cmd = Command::new(path);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -78,7 +78,7 @@ fn get_base_command() -> Command {
     if let Some(runner) = find_runner() {
         let mut runner = runner.split_whitespace();
         cmd = Command::new(runner.next().unwrap());
-        while let Some(arg) = runner.next() {
+        for arg in runner {
             cmd.arg(arg);
         }
         cmd.arg(path);


### PR DESCRIPTION
Something I [overlooked](https://github.com/ducaale/xh/runs/7273340419?check_suite_focus=true) while testing cross v.0.2.2 was the updated values for `CARGO_TARGET_${target}_RUNNER`.

This PR updates `get_base_command()` to handle runner with multiple arguments e.g `/qemu-runner aarch64` and `/linux-runner armv7`.