### PR TITLE
Support for bearer auth in .netrc

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -38,9 +38,9 @@ impl Auth {
 
     pub fn from_netrc(auth_type: AuthType, entry: netrc::Entry) -> Option<Auth> {
         match auth_type {
-            AuthType::basic => Some(Auth::Basic(entry.login, Some(entry.password))),
-            AuthType::bearer => None,
-            AuthType::digest => Some(Auth::Digest(entry.login, entry.password)),
+            AuthType::basic => Some(Auth::Basic(entry.login?, Some(entry.password))),
+            AuthType::bearer => Some(Auth::Bearer(entry.password)),
+            AuthType::digest => Some(Auth::Digest(entry.login?, entry.password)),
         }
     }
 
@@ -49,7 +49,7 @@ impl Auth {
     pub fn supports_netrc(auth_type: AuthType) -> bool {
         match auth_type {
             AuthType::basic => true,
-            AuthType::bearer => false,
+            AuthType::bearer => true,
             AuthType::digest => true,
         }
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -43,16 +43,6 @@ impl Auth {
             AuthType::digest => Some(Auth::Digest(entry.login?, entry.password)),
         }
     }
-
-    // Could be a method on AuthType instead, but it's helpful
-    // to put next to `Auth::from_netrc`
-    pub fn supports_netrc(auth_type: AuthType) -> bool {
-        match auth_type {
-            AuthType::basic => true,
-            AuthType::bearer => true,
-            AuthType::digest => true,
-        }
-    }
 }
 
 pub fn parse_auth(auth: &str, host: &str) -> io::Result<(String, Option<String>)> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,7 +407,7 @@ fn run(args: Cli) -> Result<i32> {
                 auth_type,
                 args.url.host_str().unwrap_or("<host>"),
             )?);
-        } else if !args.ignore_netrc && Auth::supports_netrc(auth_type) {
+        } else if !args.ignore_netrc {
             // I don't know if it's possible for host() to return None
             // But if it does we still want to use the default entry, if there is one
             let host = args.url.host().unwrap_or(url::Host::Domain(""));

--- a/src/netrc.rs
+++ b/src/netrc.rs
@@ -12,9 +12,6 @@
 //!
 //! - The default entry doesn't have to be at the end of the file.
 //!
-//! This implementation additionally handles entries with just a password and no login,
-//! to support using .netrc for bearer auth.
-//!
 //! HTTPie uses the implementation from Python's standard library
 //! (with a wrapper from requests).
 //!
@@ -22,6 +19,9 @@
 //! We'd ignore errors anyway to match HTTPie so that might be for the best.
 //! (HTTPie's parser is strict, so a minor problem will silently stop the file
 //! from being used.)
+//!
+//! This implementation additionally handles entries with just a password and no login,
+//! to support using .netrc for bearer auth.
 //!
 //! This is too specialized for our use case to be a crate, but feel free to
 //! copy/paste into another project and modify.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -837,6 +837,45 @@ fn netrc_env_user_password_auth() {
 }
 
 #[test]
+fn netrc_env_no_bearer_auth_unless_specified() {
+    // Test that we don't pass an authorization header if the .netrc contains no username,
+    // and the --auth-type=bearer flag isn't explicitly specified.
+    let server = server::http(|req| async move {
+        assert!(req.headers().get("Authorization").is_none());
+        hyper::Response::default()
+    });
+
+    let mut netrc = NamedTempFile::new().unwrap();
+    writeln!(netrc, "machine {}\npassword pass", server.host()).unwrap();
+
+    get_command()
+        .env("NETRC", netrc.path())
+        .arg(server.base_url())
+        .assert()
+        .success();
+}
+
+#[test]
+fn netrc_env_auth_type_bearer() {
+    // If we're using --auth-type=bearer, test that it's properly sent with a .netrc that
+    // contains only a password and no username.
+    let server = server::http(|req| async move {
+        assert_eq!(req.headers()["Authorization"], "Bearer pass");
+        hyper::Response::default()
+    });
+
+    let mut netrc = NamedTempFile::new().unwrap();
+    writeln!(netrc, "machine {}\npassword pass", server.host()).unwrap();
+
+    get_command()
+        .env("NETRC", netrc.path())
+        .arg(server.base_url())
+        .arg("--auth-type=bearer")
+        .assert()
+        .success();
+}
+
+#[test]
 fn netrc_file_user_password_auth() {
     for netrc_file in &[".netrc", "_netrc"] {
         let server = server::http(|req| async move {


### PR DESCRIPTION
Previously the `.netrc` only handled authorization that contains both a username and password.

This is a divergence from the behavior of httpie.

This only activates when `--auth-type bearer` is specified without the `--auth` flag, so I believe it should be a compatible change. (I believe previously using it like this would have always reported an error?)