### PR TITLE
Remove `#[allow(non_camel_case_types)]`

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -21,26 +21,26 @@ pub enum Auth {
 impl Auth {
     pub fn from_str(auth: &str, auth_type: AuthType, host: &str) -> Result<Auth> {
         match auth_type {
-            AuthType::basic => {
+            AuthType::Basic => {
                 let (username, password) = parse_auth(auth, host)?;
                 Ok(Auth::Basic(username, password))
             }
-            AuthType::digest => {
+            AuthType::Digest => {
                 let (username, password) = parse_auth(auth, host)?;
                 Ok(Auth::Digest(
                     username,
                     password.unwrap_or_else(|| "".into()),
                 ))
             }
-            AuthType::bearer => Ok(Auth::Bearer(auth.into())),
+            AuthType::Bearer => Ok(Auth::Bearer(auth.into())),
         }
     }
 
     pub fn from_netrc(auth_type: AuthType, entry: netrc::Entry) -> Option<Auth> {
         match auth_type {
-            AuthType::basic => Some(Auth::Basic(entry.login?, Some(entry.password))),
-            AuthType::bearer => Some(Auth::Bearer(entry.password)),
-            AuthType::digest => Some(Auth::Digest(entry.login?, entry.password)),
+            AuthType::Basic => Some(Auth::Basic(entry.login?, Some(entry.password))),
+            AuthType::Bearer => Some(Auth::Bearer(entry.password)),
+            AuthType::Digest => Some(Auth::Digest(entry.login?, entry.password)),
         }
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -305,25 +305,25 @@ impl Buffer {
 
     pub fn guess_pretty(&self) -> Pretty {
         if test_default_color() {
-            Pretty::all
+            Pretty::All
         } else if test_pretend_term() {
-            Pretty::format
+            Pretty::Format
         } else if self.is_terminal() {
             // Based on termcolor's logic for ColorChoice::Auto
             if cfg!(test) {
-                Pretty::all
+                Pretty::All
             } else if var_os("NO_COLOR").is_some() {
-                Pretty::format
+                Pretty::Format
             } else {
                 match var_os("TERM") {
-                    Some(term) if term == "dumb" => Pretty::format,
-                    Some(_) => Pretty::all,
-                    None if cfg!(windows) => Pretty::all,
-                    None => Pretty::format,
+                    Some(term) if term == "dumb" => Pretty::Format,
+                    Some(_) => Pretty::All,
+                    None if cfg!(windows) => Pretty::All,
+                    None => Pretty::Format,
                 }
             }
         } else {
-            Pretty::none
+            Pretty::None
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -469,7 +469,7 @@ impl Cli {
             self.default_scheme = Some("https".to_string());
         }
         if self.bearer.is_some() {
-            self.auth_type = Some(AuthType::bearer);
+            self.auth_type = Some(AuthType::Bearer);
             self.auth = self.bearer.take();
         }
         self.check_status = match (self.check_status_raw, matches.is_present("no-check-status")) {
@@ -666,28 +666,25 @@ fn generate_completions(mut app: clap::Command, rest_args: Vec<String>) -> Error
     safe_exit();
 }
 
-#[allow(non_camel_case_types)]
 #[derive(ArgEnum, Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AuthType {
-    basic,
-    bearer,
-    digest,
+    Basic,
+    Bearer,
+    Digest,
 }
 
 impl Default for AuthType {
     fn default() -> Self {
-        AuthType::basic
+        AuthType::Basic
     }
 }
 
-// Uppercase variant names would show up as such in the help text
-#[allow(non_camel_case_types)]
 #[derive(ArgEnum, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Pretty {
-    all,
-    colors,
-    format,
-    none,
+    All,
+    Colors,
+    Format,
+    None,
 }
 
 /// The caller must check in advance if the string is valid. (clap does this.)
@@ -705,30 +702,29 @@ fn parse_tls_version(text: &str) -> Option<tls::Version> {
 
 impl Pretty {
     pub fn color(self) -> bool {
-        matches!(self, Pretty::colors | Pretty::all)
+        matches!(self, Pretty::Colors | Pretty::All)
     }
 
     pub fn format(self) -> bool {
-        matches!(self, Pretty::format | Pretty::all)
+        matches!(self, Pretty::Format | Pretty::All)
     }
 }
 
-#[allow(non_camel_case_types)]
 #[derive(ArgEnum, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Theme {
-    auto,
-    solarized,
-    monokai,
-    fruity,
+    Auto,
+    Solarized,
+    Monokai,
+    Fruity,
 }
 
 impl Theme {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Theme::auto => "ansi",
-            Theme::solarized => "solarized",
-            Theme::monokai => "monokai",
-            Theme::fruity => "fruity",
+            Theme::Auto => "ansi",
+            Theme::Solarized => "solarized",
+            Theme::Monokai => "monokai",
+            Theme::Fruity => "fruity",
         }
     }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -116,7 +116,7 @@ pub struct Printer {
 
 impl Printer {
     pub fn new(pretty: Pretty, theme: Option<Theme>, stream: bool, buffer: Buffer) -> Self {
-        let theme = theme.unwrap_or(Theme::auto);
+        let theme = theme.unwrap_or(Theme::Auto);
 
         Printer {
             indent_json: pretty.format(),
@@ -785,7 +785,7 @@ mod tests {
         let p = Printer {
             indent_json: false,
             color: false,
-            theme: Theme::auto,
+            theme: Theme::Auto,
             sort_headers: false,
             stream: false,
             buffer: Buffer::new(false, None, false).unwrap(),

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -284,19 +284,19 @@ pub fn translate(args: Cli) -> Result<Command> {
     }
     if let Some(auth) = args.auth {
         match args.auth_type.unwrap_or_default() {
-            AuthType::basic => {
+            AuthType::Basic => {
                 cmd.arg("--basic");
                 // curl implements this flag the same way, including password prompt
                 cmd.opt("-u", "--user");
                 cmd.arg(auth);
             }
-            AuthType::digest => {
+            AuthType::Digest => {
                 cmd.arg("--digest");
                 // curl implements this flag the same way, including password prompt
                 cmd.opt("-u", "--user");
                 cmd.arg(auth);
             }
-            AuthType::bearer => {
+            AuthType::Bearer => {
                 cmd.arg("--oauth2-bearer");
                 cmd.arg(auth);
             }


### PR DESCRIPTION
This is because variant names are shown up in kebab case by default.