### PR TITLE
Warn users when --follow + non GET method

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,6 +197,10 @@ fn run(args: Cli) -> Result<i32> {
         return Err(anyhow!("This binary was built without native-tls support"));
     }
 
+    if args.follow && method != reqwest::Method::GET {
+        warn("HTTP redirections do not retain the HTTP method. Use --method GET to silence this warning.");
+    }
+
     let mut exit_code: i32 = 0;
     let mut resume: Option<u64> = None;
     let mut auth = None;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2894,3 +2894,19 @@ fn empty_response_with_content_encoding_and_content_length() {
 
         "#});
 }
+
+#[test]
+fn check_non_get_redirect_warning() {
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .status(200)
+            .body("".into())
+            .unwrap()
+    });
+
+    redirecting_command()
+        .args(&["--follow", "POST", &server.base_url()])
+        .assert()
+        .code(0)
+        .stderr("xh: warning: HTTP redirections do not retain the HTTP method. Use --method GET to silence this warning.\n");
+}


### PR DESCRIPTION
see #277.

It adds following warning when --follow is used in combination with a non GET method.
```
HTTP redirections do not retain the HTTP method. Use --method GET to silence this warning.
```

Added basic test (check_non_get_redirect_warning).


