### PR TITLE
Warn users when --curl and --follow + non GET method 

### DIFF
--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -118,7 +118,7 @@ pub fn translate(args: Cli) -> Result<Command> {
         }
     }
 
-    if args.follow && !matches!(args.method, Some(Method::GET) | None){
+    if args.follow && !matches!(args.method, Some(Method::GET) | None) {
         cmd.warn("Using a combination of -X/--request and -L/--location which may cause unintended side effects.");
     }
 

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -118,7 +118,7 @@ pub fn translate(args: Cli) -> Result<Command> {
         }
     }
 
-    if args.curl && args.follow && args.method.as_ref().map(|m| m != &Method::GET).unwrap_or(false) {
+    if args.follow && !matches!(args.method, Some(Method::GET) | None){
         cmd.warn("Using a combination of -X/--request and -L/--location which may cause unintended side effects.");
     }
 

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -118,6 +118,10 @@ pub fn translate(args: Cli) -> Result<Command> {
         }
     }
 
+    if args.curl && args.follow && args.method.as_ref().map(|m| m != &Method::GET).unwrap_or(false) {
+        cmd.warn("Using a combination of -X/--request and -L/--location which may cause unintended side effects.");
+    }
+
     // Silently ignored:
     // - .ignore_stdin: assumed by default
     //   (to send stdin, --data-binary @- -H 'Content-Type: application/octet-stream')

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3056,3 +3056,11 @@ fn empty_response_with_content_encoding_and_content_length() {
 
         "#});
 }
+
+#[test]
+fn check_non_get_redirect_warning() {
+    get_command()
+        .args(&["--follow", "--curl", "POST", "http://example.com"])
+        .assert()
+        .stderr(contains("Using a combination of -X/--request and -L/--location which may cause unintended side effects."));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3058,7 +3058,7 @@ fn empty_response_with_content_encoding_and_content_length() {
 }
 
 #[test]
-fn check_non_get_redirect_warning() {
+fn non_get_redirect_translation_warning() {
     get_command()
         .args(&["--follow", "--curl", "POST", "http://example.com"])
         .assert()


### PR DESCRIPTION
see #277 

It adds following warning when --curl (translating to culr) and --follow is used in combination with a non GET method.
```
Using a combination of -X/--request and -L/--location which may cause unintended side effects.
```

Added basic test (check_non_get_redirect_warning).