### PR TITLE
allow to build with native-tls only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             flags: --features=native-tls
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            flags: --no-default-features --features=native-tls,online-tests # disables rustls
           - target: x86_64-apple-darwin
             os: macos-latest
             flags: --features=native-tls
@@ -72,7 +75,7 @@ jobs:
           command: fmt
           args: -- --check
 
-      - name: Clippy
+      - name: Clippy (default features)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -83,3 +86,9 @@ jobs:
         with:
           command: clippy
           args: --all-features --tests -- -D warnings -A unknown-lints
+
+      - name: Clippy (native-tls only)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features --features=native-tls,online-tests --tests -- -D warnings -A unknown-lints

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             flags: --features=native-tls
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            flags: --no-default-features --features=native-tls,online-tests # disables rustls
           - target: x86_64-apple-darwin
             os: macos-latest
             flags: --features=native-tls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ url = "2.2.2"
 [dependencies.reqwest]
 version = "0.11.10"
 default-features = false
-features = ["rustls-tls", "rustls-tls-webpki-roots", "rustls-tls-native-roots", "json", "multipart", "blocking", "socks", "cookies"]
+features = ["json", "multipart", "blocking", "socks", "cookies"]
 
 [dependencies.syntect]
 version = "4.4"
@@ -73,10 +73,11 @@ tokio = { version = "1", features = ["rt", "sync", "time"] }
 tempfile = "3.2.0"
 
 [features]
-default = ["online-tests"]
+default = ["online-tests", "rustls"]
 online-tests = []
-native-tls = ["reqwest/native-tls", "reqwest/native-tls-alpn"]
 ipv6-tests=[]
+native-tls = ["reqwest/native-tls", "reqwest/native-tls-alpn"]
+rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-webpki-roots", "reqwest/rustls-tls-native-roots"]
 
 [package.metadata.cross.build.env]
 passthrough = ["CARGO_PROFILE_RELEASE_LTO"]

--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,11 @@ fn feature_status(feature: &str) -> String {
 }
 
 fn features() -> String {
-    feature_status("native-tls")
+    format!(
+        "{} {}",
+        &feature_status("native-tls"),
+        &feature_status("rustls")
+    )
 }
 
 fn main() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,7 +258,7 @@ pub struct Cli {
     pub ssl: Option<std::option::Option<tls::Version>>,
 
     /// Use the system TLS library instead of rustls (if enabled at compile time).
-    #[clap(long)]
+    #[clap(long, hide = cfg!(not(all(feature = "native-tls", feature = "rustls"))))]
     pub native_tls: bool,
 
     /// The default scheme to use if not specified in the URL.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -462,6 +462,10 @@ impl Cli {
             )
         })?;
 
+        if cfg!(not(feature = "rustls")) {
+            cli.native_tls = true;
+        }
+
         Ok(cli)
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1280,7 +1280,7 @@ fn native_tls_works() {
         .success();
 }
 
-#[cfg(all(feature = "native-tls", feature = "online-tests"))]
+#[cfg(all(feature = "native-tls", feature = "rustls", feature = "online-tests"))]
 #[test]
 fn improved_https_ip_error_with_support() {
     let server = server::http(|_req| async move {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1298,7 +1298,7 @@ fn improved_https_ip_error_with_support() {
         .stderr(contains("using the --native-tls flag"));
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(all(feature = "native-tls", feature = "rustls"))]
 #[test]
 fn auto_nativetls() {
     get_command()
@@ -1362,6 +1362,7 @@ fn unsupported_tls_version_nativetls() {
         .stderr(contains("running without the --native-tls"));
 }
 
+#[cfg(feature = "rustls")]
 #[test]
 fn unsupported_tls_version_rustls() {
     #[cfg(feature = "native-tls")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use assert_cmd::cmd::Command;
 use indoc::indoc;
+use predicates::boolean::PredicateBooleanExt;
 use predicates::function::function;
 use predicates::str::contains;
 use tempfile::{tempdir, NamedTempFile, TempDir};
@@ -1134,7 +1135,8 @@ fn verify_default_yes() {
         .assert()
         .failure()
         .stdout(contains("GET / HTTP/1.1"))
-        .stderr(contains("UnknownIssuer"));
+        // rustls or native-tls
+        .stderr(contains("UnknownIssuer").or(contains("self signed certificate")));
 }
 
 #[cfg(feature = "online-tests")]
@@ -1145,7 +1147,8 @@ fn verify_explicit_yes() {
         .assert()
         .failure()
         .stdout(contains("GET / HTTP/1.1"))
-        .stderr(contains("UnknownIssuer"));
+        // rustls or native-tls
+        .stderr(contains("UnknownIssuer").or(contains("self signed certificate")));
 }
 
 #[cfg(feature = "online-tests")]
@@ -1159,7 +1162,7 @@ fn verify_no() {
         .stderr(predicates::str::is_empty());
 }
 
-#[cfg(feature = "online-tests")]
+#[cfg(all(feature = "rustls", feature = "online-tests"))]
 #[test]
 fn verify_valid_file() {
     get_command()


### PR DESCRIPTION
Bundling (static linking) TLS library is a very bad idea from the security perspective and Linux distributions try to avoid it. This will allow to build xh with native-tls (i.e. dynamically linked system-provided TLS library) only, without rustls.