### PR TITLE
Switch from ipify.org to icanhazip.com

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1199,7 +1199,7 @@ fn cert_without_key() {
 #[test]
 fn use_ipv4() {
     get_command()
-        .args(&["https://api64.ipify.org", "--body", "--ipv4"])
+        .args(&["https://ipv4.icanhazip.com", "--body", "--ipv4"])
         .assert()
         .stdout(function(|output: &str| {
             IpAddr::from_str(output.trim()).unwrap().is_ipv4()
@@ -1212,7 +1212,7 @@ fn use_ipv4() {
 #[test]
 fn use_ipv6() {
     get_command()
-        .args(&["https://api64.ipify.org", "--body", "--ipv6"])
+        .args(&["https://ipv6.icanhazip.com", "--body", "--ipv6"])
         .assert()
         .stdout(function(|output: &str| {
             IpAddr::from_str(output.trim()).unwrap().is_ipv6()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1199,7 +1199,7 @@ fn cert_without_key() {
 #[test]
 fn use_ipv4() {
     get_command()
-        .args(&["https://ipv4.icanhazip.com", "--body", "--ipv4"])
+        .args(&["https://icanhazip.com", "--body", "--ipv4"])
         .assert()
         .stdout(function(|output: &str| {
             IpAddr::from_str(output.trim()).unwrap().is_ipv4()
@@ -1212,7 +1212,7 @@ fn use_ipv4() {
 #[test]
 fn use_ipv6() {
     get_command()
-        .args(&["https://ipv6.icanhazip.com", "--body", "--ipv6"])
+        .args(&["https://icanhazip.com", "--body", "--ipv6"])
         .assert()
         .stdout(function(|output: &str| {
             IpAddr::from_str(output.trim()).unwrap().is_ipv6()


### PR DESCRIPTION
The latter is currently operated by Cloudflare and should be more [reliable](https://github.com/ducaale/xh/actions/runs/3131272389/jobs/5082439970) than ipify.org.

Also, see https://major.io/icanhazip-com-faq/