### PR TITLE
Disable cert verification tests for native-tls

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 
 use assert_cmd::cmd::Command;
 use indoc::indoc;
-use predicates::boolean::PredicateBooleanExt;
 use predicates::function::function;
 use predicates::str::contains;
 use tempfile::{tempdir, NamedTempFile, TempDir};
@@ -1127,9 +1126,12 @@ fn proxy_multiple_valid_proxies() {
     cmd.assert().success();
 }
 
-#[cfg(feature = "online-tests")]
+// temporarily disabled for builds not using rustls
+#[cfg(all(feature = "online-tests", feature = "rustls"))]
 #[test]
 fn verify_default_yes() {
+    use predicates::boolean::PredicateBooleanExt;
+
     get_command()
         .args(["-v", "https://self-signed.badssl.com"])
         .assert()
@@ -1139,9 +1141,12 @@ fn verify_default_yes() {
         .stderr(contains("UnknownIssuer").or(contains("self signed certificate")));
 }
 
-#[cfg(feature = "online-tests")]
+// temporarily disabled for builds not using rustls
+#[cfg(all(feature = "online-tests", feature = "rustls"))]
 #[test]
 fn verify_explicit_yes() {
+    use predicates::boolean::PredicateBooleanExt;
+
     get_command()
         .args(["-v", "--verify=yes", "https://self-signed.badssl.com"])
         .assert()


### PR DESCRIPTION
This is until we can figure out why `verify_explicit_yes` and `verify_default_yes` don't [fail](https://github.com/ducaale/xh/actions/runs/3493074778/jobs/5847498749) outside of the CI

```
"xh: error: error sending request for url (https://self-signed.badssl.com/): error trying to connect: error:0A000086:SSL routinesthread \'main\' panicked at \'called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 0, error_len: Some(1) }\', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.36/src/error.rs:223:40\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n"
', /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/ops/function.rs:227:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```