### PR TITLE
Add request and keep encoding for download body flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,10 @@ Defaults to \"format\" if the NO_COLOR env is set and to \"none\" if stdout is n
     #[clap(short = 'd', long)]
     pub download: bool,
 
+    /// During download, request a content encoding and skip decompression.
+    #[clap(long)]
+    pub download_encoding: Option<String>,
+
     /// Resume an interrupted download. Requires --download and --output.
     #[clap(
         short = 'c',

--- a/src/download.rs
+++ b/src/download.rs
@@ -160,6 +160,7 @@ const UNCOLORED_SPINNER_TEMPLATE: &str = "{spinner} {bytes} {bytes_per_sec} {wid
 
 pub fn download_file(
     mut response: Response,
+    do_decompress: bool,
     file_name: Option<PathBuf>,
     // If we fall back on taking the filename from the URL it has to be the
     // original URL, before redirects. That's less surprising and matches
@@ -244,9 +245,13 @@ pub fn download_file(
         pb.reset_eta();
     }
 
+    let compression_type = if do_decompress {
+        get_compression_type(response.headers())
+    } else {
+        None
+    };
     match pb {
         Some(ref pb) => {
-            let compression_type = get_compression_type(response.headers());
             copy_largebuf(
                 &mut decompress(&mut pb.wrap_read(response), compression_type),
                 &mut buffer,
@@ -267,7 +272,6 @@ pub fn download_file(
             }
         }
         None => {
-            let compression_type = get_compression_type(response.headers());
             copy_largebuf(
                 &mut decompress(&mut response, compression_type),
                 &mut buffer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,9 +465,14 @@ fn run(args: Cli) -> Result<i32> {
     };
 
     if args.download {
-        request
-            .headers_mut()
-            .insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
+        let encoding = args
+            .download_encoding
+            .clone()
+            .unwrap_or_else(|| "identity".to_string());
+        request.headers_mut().insert(
+            ACCEPT_ENCODING,
+            HeaderValue::from_str(encoding.as_str()).unwrap(),
+        );
     }
 
     let buffer = Buffer::new(
@@ -555,6 +560,7 @@ fn run(args: Cli) -> Result<i32> {
             if exit_code == 0 {
                 download_file(
                     response,
+                    args.download_encoding.is_none(),
                     args.output,
                     &args.url,
                     resume,


### PR DESCRIPTION
## Changes

Add a `--download-encoding` flag to choose an Accept-Encoding header other than `"identity"` during a download request. During the download, the "decompress" function that reads the response and writes it to the output will passthrough data in whatever Content-Encoding was received if `--download-encoding` was specified.

## Motivation
When downloading a large file, I want to be able to transfer it compressed and leave it compressed. For example, stream download a 500MiB CSV file in the gzip encoding, saving it to a data.csv.gz file.

```
jwtrueb@jmbp xh % cargo run --release -- get http://localhost:3000/download/csv/asdf -d --download-encoding gzip
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Type: application/csv
Date: Tue, 29 Nov 2022 23:17:12 GMT
Transfer-Encoding: chunked
Vary: accept-encoding

Downloading to "asdf"
Done. 147B in 0.00177s (80.92KiB/s)
jwtrueb@jmbp xh % gzcat asdf
ts,user_id,device_id,source,pressure,temperature,humidity
2022-11-28T20:13:12.704030+00:00,2,5,1,99999.0,25.3,16.4
2022-11-28T20:14:02.446438+00:00,2,5,1,99699.0,25.1,16.2
```