### PR TITLE
Fix panic when parsing connection timeout

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1071,18 +1071,16 @@ impl FromStr for Timeout {
 
     fn from_str(sec: &str) -> anyhow::Result<Timeout> {
         match f64::from_str(sec) {
-            Ok(s) => {
-                if !s.is_finite() {
-                    Err(anyhow!("Connection timeout is not finite"))
-                } else if s.is_sign_negative() {
+            Ok(s) if !s.is_nan() => {
+                if s.is_sign_negative() {
                     Err(anyhow!("Connection timeout is negative"))
-                } else if s >= Duration::MAX.as_secs_f64() {
+                } else if s >= Duration::MAX.as_secs_f64() || s.is_infinite() {
                     Err(anyhow!("Connection timeout is too big"))
                 } else {
                     Ok(Timeout(Duration::from_secs_f64(s)))
                 }
             }
-            _ => Err(anyhow!("Connection timeout is not float value")),
+            _ => Err(anyhow!("Connection timeout is not a valid number")),
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -662,12 +662,6 @@ fn timeout_no_limit() {
 #[test]
 fn timeout_invalid() {
     get_command()
-        .args(["--timeout=inf", "--offline", ":"])
-        .assert()
-        .failure()
-        .stderr(contains("Connection timeout is not finite"));
-
-    get_command()
         .args(["--timeout=-0.01", "--offline", ":"])
         .assert()
         .failure()
@@ -680,10 +674,22 @@ fn timeout_invalid() {
         .stderr(contains("Connection timeout is too big"));
 
     get_command()
+        .args(["--timeout=inf", "--offline", ":"])
+        .assert()
+        .failure()
+        .stderr(contains("Connection timeout is too big"));
+
+    get_command()
+        .args(["--timeout=NaN", "--offline", ":"])
+        .assert()
+        .failure()
+        .stderr(contains("Connection timeout is not a valid number"));
+
+    get_command()
         .args(["--timeout=SEC", "--offline", ":"])
         .assert()
         .failure()
-        .stderr(contains("Connection timeout is not float value"));
+        .stderr(contains("Connection timeout is not a valid number"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -662,10 +662,28 @@ fn timeout_no_limit() {
 #[test]
 fn timeout_invalid() {
     get_command()
+        .args(["--timeout=inf", "--offline", ":"])
+        .assert()
+        .failure()
+        .stderr(contains("Connection timeout is not finite"));
+
+    get_command()
         .args(["--timeout=-0.01", "--offline", ":"])
         .assert()
         .failure()
-        .stderr(contains("Invalid seconds as connection timeout"));
+        .stderr(contains("Connection timeout is negative"));
+
+    get_command()
+        .args(["--timeout=18446744073709552000", "--offline", ":"])
+        .assert()
+        .failure()
+        .stderr(contains("Connection timeout is too big"));
+
+    get_command()
+        .args(["--timeout=SEC", "--offline", ":"])
+        .assert()
+        .failure()
+        .stderr(contains("Connection timeout is not float value"));
 }
 
 #[test]


### PR DESCRIPTION
Panic if seconds of connection timeout is greater than `Duration::MAX` or not finite (see [`Duration::from_secs_f64`](https://doc.rust-lang.org/std/time/struct.Duration.html#method.from_secs_f64)), so fix this.

Note this can be simplified when [`Duration::try_from_secs_f64`](https://doc.rust-lang.org/std/time/struct.Duration.html#method.try_from_secs_f64) is stabilized.