### PR TITLE
Document `NO_PROXY` env variable

### DIFF
--- a/doc/man-template.roff
+++ b/doc/man-template.roff
@@ -88,8 +88,8 @@ Sets the proxy server to use for HTTP.
 Sets the proxy server to use for HTTPS.
 .TP
 .B NO_PROXY
-List of comma seperated host names where proxy server is ignored. Use "*"
-to match all host names.
+List of comma-separated hosts for which to ignore the other proxy environment
+variables. "*" matches all host names.
 .TP
 .B NETRC
 Location of the .netrc file.

--- a/doc/man-template.roff
+++ b/doc/man-template.roff
@@ -81,11 +81,15 @@ environment variable is to rename the binary to either http or https.
 .BR REQUESTS_CA_BUNDLE ", " CURL_CA_BUNDLE
 Sets a custom CA bundle path.
 .TP
+.B http_proxy
+Sets the proxy server to use for HTTP.
+.TP
 .B HTTPS_PROXY
 Sets the proxy server to use for HTTPS.
 .TP
-.B http_proxy
-Sets the proxy server to use for HTTP.
+.B NO_PROXY
+List of comma seperated host names where proxy server is ignored. Use "*"
+to match all host names.
 .TP
 .B NETRC
 Location of the .netrc file.

--- a/doc/man-template.roff
+++ b/doc/man-template.roff
@@ -81,10 +81,10 @@ environment variable is to rename the binary to either http or https.
 .BR REQUESTS_CA_BUNDLE ", " CURL_CA_BUNDLE
 Sets a custom CA bundle path.
 .TP
-.B http_proxy
+.BR http_proxy "=[protocol://]<host>[:port]"
 Sets the proxy server to use for HTTP.
 .TP
-.B HTTPS_PROXY
+.BR HTTPS_PROXY "=[protocol://]<host>[:port]"
 Sets the proxy server to use for HTTPS.
 .TP
 .B NO_PROXY

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -332,15 +332,15 @@ environment variable is to rename the binary to either http or https.
 .BR REQUESTS_CA_BUNDLE ", " CURL_CA_BUNDLE
 Sets a custom CA bundle path.
 .TP
-.B http_proxy
+.BR http_proxy "=[protocol://]<host>[:port]"
 Sets the proxy server to use for HTTP.
 .TP
-.B HTTPS_PROXY
+.BR HTTPS_PROXY "=[protocol://]<host>[:port]"
 Sets the proxy server to use for HTTPS.
 .TP
 .B NO_PROXY
-List of comma seperated host names where proxy server is ignored. Use "*"
-to match all host names.
+List of comma-separated hosts for which to ignore the other proxy environment
+variables. "*" matches all host names.
 .TP
 .B NETRC
 Location of the .netrc file.

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -1,4 +1,4 @@
-.TH XH 1 2022-11-08 0.17.0 "User Commands"
+.TH XH 1 2022-12-13 0.17.0 "User Commands"
 
 .SH NAME
 xh \- Friendly and fast tool for sending HTTP requests
@@ -332,11 +332,15 @@ environment variable is to rename the binary to either http or https.
 .BR REQUESTS_CA_BUNDLE ", " CURL_CA_BUNDLE
 Sets a custom CA bundle path.
 .TP
+.B http_proxy
+Sets the proxy server to use for HTTP.
+.TP
 .B HTTPS_PROXY
 Sets the proxy server to use for HTTPS.
 .TP
-.B http_proxy
-Sets the proxy server to use for HTTP.
+.B NO_PROXY
+List of comma seperated host names where proxy server is ignored. Use "*"
+to match all host names.
 .TP
 .B NETRC
 Location of the .netrc file.


### PR DESCRIPTION
This is something I noticed while looking into https://github.com/ducaale/xh/issues/296.

I also wanted to document `ALL_PROXY` but that [isn't supported in reqwest](https://github.com/seanmonstar/reqwest/issues/1414) yet. Perhaps we could send a PR to reqwest or add to it xh manually?