### PR TITLE
Support duplicate header keys in session files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -321,8 +321,13 @@ fn run(args: Cli) -> Result<i32> {
 
     if let Some(ref mut s) = session {
         auth = s.auth()?;
-        for (key, value) in s.headers()?.iter() {
-            headers.entry(key).or_insert_with(|| value.clone());
+
+        let mut session_headers = s.headers()?;
+        for key in headers.keys() {
+            session_headers.remove(key);
+        }
+        for (key, value) in session_headers.iter() {
+            headers.append(key, value.clone());
         }
         s.save_headers(&headers)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,13 +322,11 @@ fn run(args: Cli) -> Result<i32> {
     if let Some(ref mut s) = session {
         auth = s.auth()?;
 
-        let mut session_headers = s.headers()?;
-        for key in headers.keys() {
-            session_headers.remove(key);
-        }
-        for (key, value) in session_headers.iter() {
-            headers.append(key, value.clone());
-        }
+        headers = {
+            let mut session_headers = s.headers()?;
+            session_headers.extend(headers);
+            session_headers
+        };
         s.save_headers(&headers)?;
 
         let mut cookie_jar = cookie_jar.lock().unwrap();

--- a/src/session.rs
+++ b/src/session.rs
@@ -51,7 +51,7 @@ struct Cookie {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Header {
-    key: String,
+    name: String,
     value: String,
 }
 
@@ -84,7 +84,7 @@ impl Content {
             self.headers = Headers::List(
                 headers
                     .into_iter()
-                    .map(|(key, value)| Header { key, value })
+                    .map(|(key, value)| Header { name: key, value })
                     .collect(),
             );
         }
@@ -130,7 +130,7 @@ impl Session {
             Headers::Map(headers) => Ok(headers.try_into()?),
             Headers::List(headers) => headers
                 .iter()
-                .map(|Header { key, value }| Ok((key.try_into()?, value.try_into()?)))
+                .map(|Header { name, value }| Ok((name.try_into()?, value.try_into()?)))
                 .collect(),
         }
     }
@@ -148,7 +148,7 @@ impl Session {
                     }
                     Headers::List(ref mut headers) => {
                         headers.push(Header {
-                            key: key.into(),
+                            name: key.into(),
                             value: value.to_str()?.into(),
                         });
                     }
@@ -445,8 +445,8 @@ mod tests {
                     "auth": {},
                     "cookies": {},
                     "headers": [
-                        {"key": "hello", "value": "world"},
-                        {"key": "hello", "value": "people"}
+                        { "name": "hello", "value": "world" },
+                        { "name": "hello", "value": "people" }
                     ]
                 }
             "#},

--- a/src/session.rs
+++ b/src/session.rs
@@ -138,9 +138,9 @@ impl Session {
     }
 
     pub fn save_headers(&mut self, request_headers: &HeaderMap) -> Result<()> {
-        let headers = match &mut self.content.headers {
+        let headers = match self.content.headers {
             Headers::Map(_) => unreachable!("headers should have been migrated to Headers::List"),
-            Headers::List(headers) => headers,
+            Headers::List(ref mut headers) => headers,
         };
 
         headers.clear();

--- a/src/session.rs
+++ b/src/session.rs
@@ -136,6 +136,10 @@ impl Session {
     }
 
     pub fn save_headers(&mut self, request_headers: &HeaderMap) -> Result<()> {
+        if let Headers::List(ref mut headers) = self.content.headers {
+            headers.clear();
+        }
+
         for (key, value) in request_headers.iter() {
             let key = key.as_str();
             // HTTPie ignores headers that are specific to a particular request e.g content-length

--- a/src/session.rs
+++ b/src/session.rs
@@ -137,21 +137,21 @@ impl Session {
         }
     }
 
-    pub fn save_headers(&mut self, request_headers: &HeaderMap) -> Result<()> {
-        let headers = match self.content.headers {
+    pub fn save_headers(&mut self, headers: &HeaderMap) -> Result<()> {
+        let session_headers = match self.content.headers {
             Headers::Map(_) => unreachable!("headers should have been migrated to Headers::List"),
             Headers::List(ref mut headers) => headers,
         };
 
-        headers.clear();
+        session_headers.clear();
 
-        for (key, value) in request_headers.iter() {
+        for (key, value) in headers.iter() {
             let key = key.as_str();
             // HTTPie ignores headers that are specific to a particular request e.g content-length
             // see https://github.com/httpie/httpie/commit/e09b74021c9c955fd7c3bab11f22801aaf9dc1b8
             // we will also ignore cookies as they are taken care of by save_cookies()
             if key != "cookie" && !key.starts_with("content-") && !key.starts_with("if-") {
-                headers.push(Header {
+                session_headers.push(Header {
                     name: key.into(),
                     value: value.to_str()?.into(),
                 });

--- a/src/session.rs
+++ b/src/session.rs
@@ -16,9 +16,16 @@ use crate::utils::{config_dir, test_mode};
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 enum Meta {
-    Xh { about: String, xh: String },
-    Httpie { httpie: String },
-    Other,
+    Xh {
+        about: String,
+        xh: String,
+    },
+    Httpie {
+        about: String,
+        help: String,
+        httpie: String,
+    },
+    Other(serde_json::Value),
 }
 
 impl Default for Meta {

--- a/src/session.rs
+++ b/src/session.rs
@@ -58,7 +58,9 @@ struct Header {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 enum Headers {
+    // old headers format kept for backward compatibility
     Map(HashMap<String, String>),
+    // new header format that supports duplicate keys
     List(Vec<Header>),
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2022,7 +2022,7 @@ fn named_sessions() {
                 "cook1": { "value": "one", "path": "/" },
                 "lang": { "value": "en" }
             },
-            "headers": {}
+            "headers": []
         })
     );
 }
@@ -2061,7 +2061,7 @@ fn anonymous_sessions() {
             },
             "auth": { "type": "basic", "raw_auth": "me:pass" },
             "cookies": { "cook1": { "value": "one" } },
-            "headers": { "hello": "world" }
+            "headers": [ {"key": "hello", "value": "world"} ]
         })
     );
 }
@@ -2140,9 +2140,9 @@ fn session_files_are_created_in_read_only_mode() {
             "cookies": {
                 "lang": { "value": "ar" }
             },
-            "headers": {
-                "hello": "world"
-            }
+            "headers": [
+                {"key": "hello", "value": "world"}
+            ]
         })
     );
 }
@@ -2258,7 +2258,7 @@ fn expired_cookies_are_removed_from_session() {
                     "value": "random_string",
                 }
             },
-            "headers": {}
+            "headers": []
         })
     );
 }
@@ -2325,7 +2325,7 @@ fn cookies_override_each_other_in_the_correct_order() {
                 "cook1": { "value": "one" },
                 "cook2": { "value": "two" }
             },
-            "headers": {}
+            "headers": []
         })
     );
 }
@@ -2434,9 +2434,9 @@ fn auth_netrc_is_not_persisted_in_session() {
             },
             "auth": { "type": null, "raw_auth": null },
             "cookies": {},
-            "headers": {
-                "hello": "world"
-            }
+            "headers": [
+                {"key": "hello", "value": "world"}
+            ]
         })
     );
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2449,13 +2449,11 @@ fn multiple_headers_with_same_key_in_session() {
             req.headers()
                 .get_all("hello")
                 .into_iter()
-                .collect::<Vec<_>>()
-                .sort(),
+                .collect::<Vec<_>>(),
             [
                 &HeaderValue::from_static("world"),
                 &HeaderValue::from_static("people")
             ]
-            .sort(),
         );
         hyper::Response::default()
     });

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2061,7 +2061,9 @@ fn anonymous_sessions() {
             },
             "auth": { "type": "basic", "raw_auth": "me:pass" },
             "cookies": { "cook1": { "value": "one" } },
-            "headers": [ {"name": "hello", "value": "world"} ]
+            "headers": [
+                { "name": "hello", "value": "world" }
+            ]
         })
     );
 }
@@ -2080,7 +2082,9 @@ fn anonymous_read_only_session() {
         "__meta__": { "about": "xh session file", "xh": "0.0.0" },
         "auth": { "type": null, "raw_auth": null },
         "cookies": { "cookie1": { "value": "one" } },
-        "headers": { "hello": "world" }
+        "headers": [
+            { "name": "hello", "value": "world" }
+        ]
     });
 
     std::fs::write(&session_file, old_session_content.to_string()).unwrap();
@@ -2141,7 +2145,7 @@ fn session_files_are_created_in_read_only_mode() {
                 "lang": { "value": "ar" }
             },
             "headers": [
-                {"name": "hello", "value": "world"}
+                { "name": "hello", "value": "world" }
             ]
         })
     );
@@ -2174,9 +2178,9 @@ fn named_read_only_session() {
         "cookies": {
             "cookie1": { "value": "one" }
         },
-        "headers": {
-            "hello": "world"
-        }
+        "headers": [
+            { "name": "hello", "value": "world" }
+        ]
     });
     fs::create_dir_all(path_to_session.parent().unwrap()).unwrap();
     File::create(&path_to_session).unwrap();
@@ -2227,7 +2231,7 @@ fn expired_cookies_are_removed_from_session() {
                     "value": "random_string",
                 }
             },
-            "headers": {}
+            "headers": []
         })
         .to_string(),
     )
@@ -2295,7 +2299,7 @@ fn cookies_override_each_other_in_the_correct_order() {
                 "lang": { "value": "fr" },
                 "cook2": { "value": "three" }
             },
-            "headers": {}
+            "headers": []
         })
         .to_string(),
     )
@@ -2345,7 +2349,7 @@ fn basic_auth_from_session_is_used() {
             "__meta__": { "about": "xh session file", "xh": "0.0.0" },
             "auth": { "type": "basic", "raw_auth": "user:pass" },
             "cookies": {},
-            "headers": {}
+            "headers": []
         })
         .to_string(),
     )
@@ -2377,7 +2381,7 @@ fn bearer_auth_from_session_is_used() {
             "__meta__": { "about": "xh session file", "xh": "0.0.0" },
             "auth": { "type": "bearer", "raw_auth": "secret-token" },
             "cookies": {},
-            "headers": {}
+            "headers": []
         })
         .to_string(),
     )
@@ -2435,7 +2439,7 @@ fn auth_netrc_is_not_persisted_in_session() {
             "auth": { "type": null, "raw_auth": null },
             "cookies": {},
             "headers": [
-                {"name": "hello", "value": "world"}
+                { "name": "hello", "value": "world" }
             ]
         })
     );

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2061,7 +2061,7 @@ fn anonymous_sessions() {
             },
             "auth": { "type": "basic", "raw_auth": "me:pass" },
             "cookies": { "cook1": { "value": "one" } },
-            "headers": [ {"key": "hello", "value": "world"} ]
+            "headers": [ {"name": "hello", "value": "world"} ]
         })
     );
 }
@@ -2141,7 +2141,7 @@ fn session_files_are_created_in_read_only_mode() {
                 "lang": { "value": "ar" }
             },
             "headers": [
-                {"key": "hello", "value": "world"}
+                {"name": "hello", "value": "world"}
             ]
         })
     );
@@ -2435,7 +2435,7 @@ fn auth_netrc_is_not_persisted_in_session() {
             "auth": { "type": null, "raw_auth": null },
             "cookies": {},
             "headers": [
-                {"key": "hello", "value": "world"}
+                {"name": "hello", "value": "world"}
             ]
         })
     );


### PR DESCRIPTION
Headers will be saved as key-value pairs, and any session using the old format will be migrated automatically

#### Before:
```json
{
  "__meta__": { "about": "xh session file", "xh": "0.0.0" },
  "auth": { "type": null, "raw_auth": null },
  "cookies": {},
  "headers": {
    "hello": "world"
  }
}
```

#### After:
```json
{
  "__meta__": { "about": "xh session file", "xh": "0.0.0" },
  "auth": { "type": null, "raw_auth": null },
  "cookies": {},
  "headers": [
    { "key": "hello", "value": "world" }
  ]
}
```

Resolves #245 