### PR TITLE
Add format options: json.format and headers.sort

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1693,4 +1693,33 @@ mod tests {
         assert_eq!(parse_encoding("notreal").is_err(), true);
         assert_eq!(parse_encoding("").is_err(), true);
     }
+
+    #[test]
+    fn parse_format_options() {
+        let invalid_format_options = vec![
+            // malformed strings
+            ":8",
+            "json.indent:",
+            ":",
+            "",
+            "json.format:true, json.indent:4",
+            // invalid values
+            "json.indent:-8",
+            "json.format:False",
+            // unsupported options
+            "json.sort_keys:true",
+            "xml.format:false",
+            "xml.indent:false",
+            // invalid options
+            "toml.format:true",
+        ];
+
+        for format_option in invalid_format_options {
+            assert!(FormatOptions::from_str(format_option).is_err());
+        }
+
+        assert!(
+            FormatOptions::from_str("json.indent:8,json.format:true,headers.sort:false").is_ok()
+        );
+    }
 }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -7,14 +7,11 @@ use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 use termcolor::WriteColor;
 
-use crate::{
-    buffer::Buffer,
-    cli::{FormatOptions, Theme},
-};
+use crate::{buffer::Buffer, cli::Theme};
 
-pub fn get_json_formatter(format_options: &FormatOptions) -> jsonxf::Formatter {
+pub fn get_json_formatter(indent_level: usize) -> jsonxf::Formatter {
     let mut fmt = jsonxf::Formatter::pretty_printer();
-    fmt.indent = " ".repeat(format_options.json_indent);
+    fmt.indent = " ".repeat(indent_level);
     fmt.record_separator = String::from("\n\n");
     fmt.eager_record_separators = true;
     fmt

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use atty::Stream;
-use cli::FormatOptions;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use redirect::RedirectFollower;
 use reqwest::blocking::Client;
@@ -485,13 +484,7 @@ fn run(args: Cli) -> Result<i32> {
         ),
     };
     let pretty = args.pretty.unwrap_or_else(|| buffer.guess_pretty());
-    let mut printer = Printer::new(
-        pretty,
-        args.style,
-        args.stream,
-        buffer,
-        args.format_options.unwrap_or(FormatOptions::default()),
-    );
+    let mut printer = Printer::new(pretty, args.style, args.stream, buffer, args.format_options);
 
     let response_charset = args.response_charset;
     let response_mime = args.response_mime.as_deref();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3288,3 +3288,55 @@ fn non_get_redirect_translation_warning() {
         .assert()
         .stderr(contains("Using a combination of -X/--request and -L/--location which may cause unintended side effects."));
 }
+
+#[test]
+fn custom_json_indent_level() {
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .header("content-type", "application/json")
+            .body(r#"{"hello":"world"}"#.into())
+            .unwrap()
+    });
+    get_command()
+        .args([
+            "--print=b",
+            "--format-options=json.indent:2",
+            &server.base_url(),
+        ])
+        .assert()
+        .stdout(indoc! {r#"
+            {
+              "hello": "world"
+            }
+
+
+        "#});
+}
+
+#[test]
+fn unsorted_headers() {
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .header("X-Foo", "Bar")
+            .header("Date", "N/A")
+            .header("Content-Type", "application/json")
+            .body(r#"{"hello":"world"}"#.into())
+            .unwrap()
+    });
+    get_command()
+        .args(["--format-options=headers.sort:false", &server.base_url()])
+        .assert()
+        .stdout(indoc! {r#"
+            HTTP/1.1 200 OK
+            X-Foo: Bar
+            Date: N/A
+            Content-Type: application/json
+            Content-Length: 17
+
+            {
+                "hello": "world"
+            }
+
+
+        "#});
+}


### PR DESCRIPTION
This is a follow-up PR to https://github.com/ducaale/xh/pull/318. 

Also, see https://httpie.io/docs/cli/format-options for all the format options supported by HTTPie.