### PR TITLE
Make network-interface an optional dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c4dbf727f42893b058d7619d5b4da3743dfe9cdb6e440880f7717a68b57e0e"
+checksum = "afd878f93491173e5d272d0dd3124ff89739e50f276c7b9857ac0d97cc024f96"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ memchr = "2.4.1"
 mime = "0.3.16"
 mime2ext = "0.1.0"
 mime_guess = "2.0"
-network-interface = "1.0.0"
+network-interface = { version = "1.0.0", optional = true }
 once_cell = "1.8.0"
 os_display = "0.1.3"
 pem = "0.8.2"
@@ -74,9 +74,12 @@ tokio = { version = "1", features = ["rt", "sync", "time"] }
 tempfile = "3.2.0"
 
 [features]
-default = ["online-tests", "rustls"]
+# Ideally network-interface would be disabled by default on certain platforms
+# However: https://github.com/rust-lang/cargo/issues/1197
+default = ["online-tests", "rustls", "network-interface"]
 native-tls = ["reqwest/native-tls", "reqwest/native-tls-alpn"]
 rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-webpki-roots", "reqwest/rustls-tls-native-roots"]
+network-interface = ["dep:network-interface"]
 
 online-tests = []
 ipv6-tests = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use atty::Stream;
 use cookie_store::{CookieStore, RawCookie};
+#[cfg(feature = "network-interface")]
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use redirect::RedirectFollower;
 use reqwest::blocking::Client;
@@ -287,26 +288,30 @@ fn run(args: Cli) -> Result<i32> {
 
     if let Some(name_or_ip) = &args.interface {
         let ip_addr = if let Ok(ip_addr) = IpAddr::from_str(name_or_ip) {
-            Some(ip_addr)
+            ip_addr
         } else {
+            #[cfg(not(feature = "network-interface"))]
+            return Err(anyhow!(
+                "This binary was built without support for binding to interfaces. Enable the `network-interface` feature."
+            ));
+
+            #[cfg(feature = "network-interface")]
             // TODO: Directly bind to interface name once hyper/reqwest adds support for it.
             // See https://github.com/seanmonstar/reqwest/issues/1336 and https://github.com/hyperium/hyper/pull/3076
-            let network_interfaces = NetworkInterface::show()?;
-            network_interfaces.iter().find_map(|interface| {
-                if &interface.name == name_or_ip {
-                    if let Some(addr) = interface.addr.first() {
-                        return Some(addr.ip());
+            NetworkInterface::show()?
+                .iter()
+                .find_map(|interface| {
+                    if &interface.name == name_or_ip {
+                        if let Some(addr) = interface.addr.first() {
+                            return Some(addr.ip());
+                        }
                     }
-                }
-                None
-            })
+                    None
+                })
+                .with_context(|| format!("Couldn't bind to {:?}", name_or_ip))?
         };
 
-        if let Some(ip_addr) = ip_addr {
-            client = client.local_address(ip_addr);
-        } else {
-            return Err(anyhow!("Couldn't bind to {:?}", name_or_ip));
-        }
+        client = client.local_address(ip_addr);
     }
 
     let client = client.build()?;


### PR DESCRIPTION
See https://github.com/ducaale/xh/issues/330

There are packages that build with `--no-default-features` but should probably enable this feature, like [Alpine's](https://git.alpinelinux.org/aports/plain/community/xh/APKBUILD?h=3.17-stable). Not sure what the best way is to communicate these things. Maybe a note in the changelog is enough.