### PR TITLE
display remote address in metadata

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -517,8 +517,14 @@ impl Printer {
             total_elapsed_time += content_download_duration.as_secs_f64();
         }
         self.buffer
-            .print(format!("Elapsed time: {:.5}s", total_elapsed_time))?;
-        self.buffer.print("\n\n")?;
+            .print(format!("Elapsed time: {:.5}s\n", total_elapsed_time))?;
+
+        if let Some(remote_addr) = response.remote_addr() {
+            self.buffer
+                .print(format!("Remote address: {:?}\n", remote_addr))?;
+        }
+
+        self.buffer.print("\n")?;
         Ok(())
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3360,7 +3360,8 @@ fn response_meta() {
         .arg("--print=m")
         .arg(server.base_url())
         .assert()
-        .stdout(contains("Elapsed time: "));
+        .stdout(contains("Elapsed time: "))
+        .stdout(contains("Remote address: "));
 }
 
 #[test]
@@ -3386,14 +3387,16 @@ fn redirect_with_response_meta() {
         .arg("--follow")
         .arg("-vv")
         .assert()
-        .stdout(contains("Elapsed time: ").count(2));
+        .stdout(contains("Elapsed time: ").count(2))
+        .stdout(contains("Remote address: ").count(2));
 
     get_command()
         .arg(server.url("/first_page"))
         .arg("--follow")
         .arg("--meta")
         .assert()
-        .stdout(contains("Elapsed time: ").count(1));
+        .stdout(contains("Elapsed time: ").count(1))
+        .stdout(contains("Remote address: ").count(1));
 }
 
 #[cfg(feature = "online-tests")]
@@ -3405,7 +3408,8 @@ fn digest_auth_with_response_meta() {
         .arg("-vv")
         .arg("httpbingo.org/digest-auth/auth/ahmed/12345")
         .assert()
-        .stdout(contains("Elapsed time: ").count(2));
+        .stdout(contains("Elapsed time: ").count(2))
+        .stdout(contains("Remote address: ").count(2));
 }
 
 #[test]


### PR DESCRIPTION
implement proposal #347 

example output

```shell
❯ cargo run -- httpbin.org/get -vv
   Compiling xh v0.20.1 (/Users/chen/mydata/xh)
    Finished dev [unoptimized + debuginfo] target(s) in 2.20s
     Running `/Users/chen/.rust-target/debug/xh httpbin.org/get -vv`
GET /get HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br
Connection: keep-alive
Host: httpbin.org
User-Agent: xh/0.20.1

HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 295
Content-Type: application/json
Date: Wed, 17 Jan 2024 04:45:33 GMT
Server: gunicorn/19.9.0

{
    "args": {},
    "headers": {
        "Accept": "*/*",
        "Accept-Encoding": "gzip, deflate, br",
        "Host": "httpbin.org",
        "User-Agent": "xh/0.20.1",
        "X-Amzn-Trace-Id": "Root=1-65a75b6d-787ccc48646e40ce75195807"
    },
    "origin": "47.242.3.58",
    "url": "http://httpbin.org/get"
}



Elapsed time: 0.67198s
Remote address: 3.224.157.95:80

```