### PR TITLE
Default `XH_CONFIG_DIR` to `~/.config/xh` in macOS

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,7 +73,7 @@ pub fn random_string() -> String {
 pub fn config_dir() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("XH_CONFIG_DIR") {
         Some(dir.into())
-    } else if cfg!(macos) {
+    } else if cfg!(target_os = "macos") {
         dirs::home_dir().map(|dir| dir.join(".config").join("xh"))
     } else {
         dirs::config_dir().map(|dir| dir.join("xh"))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,7 +77,11 @@ pub fn config_dir() -> Option<PathBuf> {
 
     if cfg!(target_os = "macos") {
         let legacy_config_dir = dirs::config_dir()?.join("xh");
-        let new_config_dir = dirs::home_dir()?.join(".config").join("xh");
+        let config_home = match var_os("XDG_CONFIG_HOME") {
+            Some(dir) => dir.into(),
+            None => dirs::home_dir()?.join(".config"),
+        };
+        let new_config_dir = config_home.join("xh");
         if legacy_config_dir.exists() && !new_config_dir.exists() {
             Some(legacy_config_dir)
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,11 +72,19 @@ pub fn random_string() -> String {
 
 pub fn config_dir() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("XH_CONFIG_DIR") {
-        Some(dir.into())
-    } else if cfg!(target_os = "macos") {
-        dirs::home_dir().map(|dir| dir.join(".config").join("xh"))
+        return Some(dir.into());
+    }
+
+    if cfg!(target_os = "macos") {
+        let legacy_config_dir = dirs::config_dir()?.join("xh");
+        let new_config_dir = dirs::home_dir()?.join(".config").join("xh");
+        if legacy_config_dir.exists() && !new_config_dir.exists() {
+            Some(legacy_config_dir)
+        } else {
+            Some(new_config_dir)
+        }
     } else {
-        dirs::config_dir().map(|dir| dir.join("xh"))
+        Some(dirs::config_dir()?.join("xh"))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,6 +73,8 @@ pub fn random_string() -> String {
 pub fn config_dir() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("XH_CONFIG_DIR") {
         Some(dir.into())
+    } else if cfg!(macos) {
+        dirs::home_dir().map(|dir| dir.join(".config").join("xh"))
     } else {
         dirs::config_dir().map(|dir| dir.join("xh"))
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,6 +76,9 @@ pub fn config_dir() -> Option<PathBuf> {
     }
 
     if cfg!(target_os = "macos") {
+        // On macOS dirs returns `~/Library/Application Support`.
+        // ~/.config is more usual so we switched to that. But first we check for
+        // the legacy location.
         let legacy_config_dir = dirs::config_dir()?.join("xh");
         let config_home = match var_os("XDG_CONFIG_HOME") {
             Some(dir) => dir.into(),


### PR DESCRIPTION
This is a potentially disruptive change but aligns us better with our docs and HTTPie.

Addresses #352