### PR TITLE
support http2-prior-knowledge

### DIFF
--- a/completions/_xh
+++ b/completions/_xh
@@ -46,7 +46,7 @@ none\:"Disable both coloring and formatting"))' \
 '--cert-key=[A private key file to use with --cert]:FILE:_files' \
 '--ssl=[Force a particular TLS version]:VERSION:(auto tls1 tls1.1 tls1.2 tls1.3)' \
 '--default-scheme=[The default scheme to use if not specified in the URL]:SCHEME: ' \
-'--http-version=[HTTP version to use]:VERSION:(1.0 1.1 2)' \
+'--http-version=[HTTP version to use]:VERSION:(1.0 1.1 2 2-prior-knowledge)' \
 '*--resolve=[Override DNS resolution for specific domain to a custom IP]:HOST:ADDRESS: ' \
 '--interface=[Bind to a network interface or local IP address]:NAME: ' \
 '-j[(default) Serialize data items from the command line as a JSON object]' \

--- a/completions/xh.bash
+++ b/completions/xh.bash
@@ -138,7 +138,7 @@ _xh() {
                     return 0
                     ;;
                 --http-version)
-                    COMPREPLY=($(compgen -W "1.0 1.1 2" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "1.0 1.1 2 2-prior-knowledge" -- "${cur}"))
                     return 0
                     ;;
                 --resolve)

--- a/completions/xh.fish
+++ b/completions/xh.fish
@@ -20,7 +20,7 @@ complete -c xh -l cert -d 'Use a client side certificate for SSL' -r -F
 complete -c xh -l cert-key -d 'A private key file to use with --cert' -r -F
 complete -c xh -l ssl -d 'Force a particular TLS version' -r -f -a "{auto	'',tls1	'',tls1.1	'',tls1.2	'',tls1.3	''}"
 complete -c xh -l default-scheme -d 'The default scheme to use if not specified in the URL' -r
-complete -c xh -l http-version -d 'HTTP version to use' -r -f -a "{1.0	'',1.1	'',2	''}"
+complete -c xh -l http-version -d 'HTTP version to use' -r -f -a "{1.0	'',1.1	'',2	'',2-prior-knowledge	''}"
 complete -c xh -l resolve -d 'Override DNS resolution for specific domain to a custom IP' -r
 complete -c xh -l interface -d 'Bind to a network interface or local IP address' -r
 complete -c xh -s j -l json -d '(default) Serialize data items from the command line as a JSON object'

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -1,4 +1,4 @@
-.TH XH 1 2024-01-28 0.21.0 "User Commands"
+.TH XH 1 2024-03-22 0.21.0 "User Commands"
 
 .SH NAME
 xh \- Friendly and fast tool for sending HTTP requests
@@ -278,7 +278,7 @@ Make HTTPS requests if not specified in the URL.
 \fB\-\-http\-version\fR=\fIVERSION\fR
 HTTP version to use.
 
-[possible values: 1.0, 1.1, 2]
+[possible values: 1.0, 1.1, 2, 2\-prior\-knowledge]
 .TP 4
 \fB\-\-resolve\fR=\fIHOST:ADDRESS\fR
 Override DNS resolution for specific domain to a custom IP.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1280,6 +1280,8 @@ pub enum HttpVersion {
     Http11,
     #[clap(name = "2")]
     Http2,
+    #[clap(name = "2-prior-knowledge")]
+    Http2PriorKnowledge,
 }
 
 /// HTTPie uses Python's str.decode(). That one's very accepting of different spellings.

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,10 @@ fn run(args: Cli) -> Result<i32> {
         client = client.http1_only();
     }
 
+    if matches!(args.http_version, Some(HttpVersion::Http2PriorKnowledge)) {
+        client = client.http2_prior_knowledge();
+    }
+
     let cookie_jar = Arc::new(reqwest_cookie_store::CookieStoreMutex::default());
     client = client.cookie_provider(cookie_jar.clone());
 
@@ -370,7 +374,9 @@ fn run(args: Cli) -> Result<i32> {
         request_builder = match args.http_version {
             Some(HttpVersion::Http10) => request_builder.version(reqwest::Version::HTTP_10),
             Some(HttpVersion::Http11) => request_builder.version(reqwest::Version::HTTP_11),
-            Some(HttpVersion::Http2) => request_builder.version(reqwest::Version::HTTP_2),
+            Some(HttpVersion::Http2 | HttpVersion::Http2PriorKnowledge) => {
+                request_builder.version(reqwest::Version::HTTP_2)
+            }
             None => request_builder,
         };
 

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -231,6 +231,7 @@ pub fn translate(args: Cli) -> Result<Command> {
             HttpVersion::Http10 => cmd.arg("--http1.0"),
             HttpVersion::Http11 => cmd.arg("--http1.1"),
             HttpVersion::Http2 => cmd.arg("--http2"),
+            HttpVersion::Http2PriorKnowledge => cmd.arg("--http2-prior-knowledge"),
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3053,6 +3053,20 @@ fn http2() {
         .stdout(contains("HTTP/2.0 200 OK"));
 }
 
+#[cfg(feature = "online-tests")]
+#[test]
+fn http2_prior_knowledge() {
+    get_command()
+        .args([
+            "--print=hH",
+            "--http-version=2-prior-knowledge",
+            "http://x.com",
+        ])
+        .assert()
+        .stdout(contains("GET / HTTP/2.0"))
+        .stdout(contains("HTTP/2.0 "));
+}
+
 #[test]
 fn override_response_charset() {
     let server = server::http(|_req| async move {


### PR DESCRIPTION


> --http2-prior-knowledge
	(HTTP) Issue a non-TLS HTTP requests using HTTP/2 directly without HTTP/1.1 Upgrade. It requires prior knowledge that the server supports HTTP/2 straight away. HTTPS requests still do HTTP/2 the standard way with negotiated protocol version in the TLS handshake.

	


https://curl.se/docs/manpage.html#--http2-prior-knowledge


current:
```
❯ xh --http-version=2 http://x.com -v
GET / HTTP/2.0
accept: */*
accept-encoding: gzip, deflate, br
host: x.com
user-agent: xh/0.21.0

xh: error: error sending request for url (http://x.com/): request has unsupported HTTP version

Caused by:
    request has unsupported HTTP version

xh on http2_prior_knowledge:master [⇡] is 📦 v0.21.0 via 🦀 v1.76.0 
```

after:
```
❯ cargo run -- --http-version=2-prior-knowledge  http://x.com -v
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `/Users/xxx/.rust-target/debug/xh --http-version=2-prior-knowledge 'http://x.com' -v`
GET / HTTP/2.0
accept: */*
accept-encoding: gzip, deflate, br
host: x.com
user-agent: xh/0.21.0

HTTP/2.0 301 Moved Permanently
cache-control: no-cache, no-store, max-age=0
content-length: 0
date: Fri, 22 Mar 2024 04:22:32 GMT
location: https://x.com/
perf: 7469935968
server: tsa_q
x-connection-hash: 7a464c1a076a5af16cde9cf3594760f6edde4ea5c7f91ef75c564d470b595130
x-response-time: 119
x-transaction-id: 9d05eb595bc41b2e
```