### PR TITLE
Use serde-transcode to optimize JSON formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-transcode"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2431,7 @@ dependencies = [
  "roff",
  "rpassword",
  "serde",
+ "serde-transcode",
  "serde_json",
  "serde_urlencoded",
  "syntect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ regex-lite = "0.1.5"
 roff = { version = "0.2.1", optional = true }
 rpassword = "7.2.0"
 serde = { version = "1.0", features = ["derive"] }
+serde-transcode = "1.1.1"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_urlencoded = "0.7.0"
 termcolor = "1.1.2"

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,6 +1,5 @@
 use std::io::{self, Write};
 
-use serde::Serialize;
 use syntect::dumps::from_binary;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
@@ -18,12 +17,16 @@ pub fn get_json_formatter(indent_level: usize) -> jsonxf::Formatter {
     fmt
 }
 
+/// Format a JSON value using serde. Unlike jsonxf this decodes escaped Unicode values.
+///
+/// Note that if parsing fails this function will stop midway through and return an error.
+/// It should only be used with known-valid JSON.
 pub fn serde_json_format(indent_level: usize, text: &str, write: impl Write) -> io::Result<()> {
     let indent = " ".repeat(indent_level);
     let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
-    let value = serde_json::from_str::<serde_json::Value>(text)?;
     let mut serializer = serde_json::Serializer::with_formatter(write, formatter);
-    value.serialize(&mut serializer)?;
+    let mut deserializer = serde_json::Deserializer::from_str(text);
+    serde_transcode::transcode(&mut deserializer, &mut serializer)?;
     Ok(())
 }
 


### PR DESCRIPTION
Followup to #361 (which I meant to look at but forgot).

Instead of parsing the JSON input into a `serde::Value` we can use [`serde-transcode`](https://lib.rs/crates/serde-transcode) to serialize straight from the input to the output. On an articial very large JSON file I use for testing this ends up five times faster. (Maybe slightly faster than `jsonxf` was?) I got this trick from jsonxf's [serde benchmark](https://github.com/gamache/jsonxf/blob/ab914dc7ed9dfaa642a37b316211328626dbef0c/benchmark/serdexf/src/main.rs).

(The rest of the PR looked great. Thanks, @zuisong!)

I also included a tiny theoretical bugfix for decompression that I wrote a while ago but didn't think was worth a PR, see the explanation in 398d5673800d06c06b39b91f24a097864b83679a