### PR TITLE
Remove `battila7/get-version-action`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,9 +107,6 @@ jobs:
             strip "target/${{ matrix.job.target }}/release/xh"
           fi
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
-
       - name: Package
         shell: bash
         run: |
@@ -118,7 +115,7 @@ jobs:
           else
             bin="target/${{ matrix.job.target }}/release/xh"
           fi
-          staging="xh-${{ steps.get_version.outputs.version }}-${{ matrix.job.target }}"
+          staging="xh-${GITHUB_REF_NAME}-${{ matrix.job.target }}"
 
           mkdir -p "$staging"/{doc,completions}
           cp LICENSE README.md $bin $staging

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
           else
             bin="target/${{ matrix.job.target }}/release/xh"
           fi
-          staging="xh-${GITHUB_REF_NAME}-${{ matrix.job.target }}"
+          staging="xh-${{ github.ref_name }}-${{ matrix.job.target }}"
 
           mkdir -p "$staging"/{doc,completions}
           cp LICENSE README.md $bin $staging


### PR DESCRIPTION
This uses deprecated commands (e.g., `set-output`) and actions (e.g., Node.js 16 actions). Also, the version number can be obtained from the [`GITHUB_REF_NAME`](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) environment variable. So, I remove this action.