### PR TITLE
Ignore `NO_COLOR` if set to empty string

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -312,7 +312,7 @@ impl Buffer {
             // Based on termcolor's logic for ColorChoice::Auto
             if cfg!(test) {
                 Pretty::All
-            } else if var_os("NO_COLOR").is_some() {
+            } else if var_os("NO_COLOR").is_some_and(|val| !val.is_empty()) {
                 Pretty::Format
             } else {
                 match var_os("TERM") {


### PR DESCRIPTION
Environment variables can have no value at all or they can have the empty string as a value. We used to disable color if `$NO_COLOR` were set at all, regardless of its value, but as of https://github.com/jcs/no_color/commit/99f90e27d0fac6a34d07998f8f577e1f2f620c61 we should ignore empty strings (and this makes more sense).

Result: `NO_COLOR= xh` now allows colors.