### PR TITLE
Prevent directory traversal in server-supplied filenames

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -551,6 +551,49 @@ fn download_supplied_unquoted_filename() {
     );
 }
 
+#[test]
+fn download_filename_with_directory_traversal() {
+    let dir = tempdir().unwrap();
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .header(
+                "Content-Disposition",
+                r#"attachment; filename="foo/baz/bar""#,
+            )
+            .body("file".into())
+            .unwrap()
+    });
+
+    get_command()
+        .args(["--download", &server.base_url()])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    assert_eq!(fs::read_to_string(dir.path().join("bar")).unwrap(), "file");
+}
+
+#[cfg(windows)]
+#[test]
+fn download_filename_with_windows_directory_traversal() {
+    let dir = tempdir().unwrap();
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .header(
+                "Content-Disposition",
+                r#"attachment; filename="foo\baz\bar""#,
+            )
+            .body("file".into())
+            .unwrap()
+    });
+
+    get_command()
+        .args(["--download", &server.base_url()])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    assert_eq!(fs::read_to_string(dir.path().join("bar")).unwrap(), "file");
+}
+
 // TODO: test implicit download filenames
 // For this we have to pretend the output is a tty
 // This intersects with both #41 and #59


### PR DESCRIPTION
If the `Content-Disposition` header includes directory separators (e.g. `/`) then we now only take the base filename. Including the directories is a vulnerability.

Originally fixed in 028cbb0165af54123a4829162a6a00f46e8dce74 but then broken again in 330d3f2ed4e1af82ef89fefce2e6e84a8ac66330. This time I added a regression test.

Fixes #378.

(Commit based on v0.22.0, we could do a bugfix release instead of a feature release.)