### PR TITLE
Fix `clippy::needless_lifetimes`

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -71,7 +71,7 @@ impl<'a> DigestAuthMiddleware<'a> {
     }
 }
 
-impl<'a> Middleware for DigestAuthMiddleware<'a> {
+impl Middleware for DigestAuthMiddleware<'_> {
     fn handle(&mut self, mut ctx: Context, mut request: Request) -> Result<Response> {
         let mut response = self.next(&mut ctx, clone_request(&mut request)?)?;
         match response.headers().get(WWW_AUTHENTICATE) {


### PR DESCRIPTION
This lint is new in Rust 1.83.