### PR TITLE
Enable logging in `rustls` and `tracing`-using dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2074,19 +2075,20 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -2542,6 +2544,7 @@ dependencies = [
  "reqwest",
  "roff",
  "rpassword",
+ "rustls",
  "ruzstd",
  "serde",
  "serde-transcode",
@@ -2553,6 +2556,7 @@ dependencies = [
  "termcolor",
  "time",
  "tokio",
+ "tracing",
  "unicode-width",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dirs = "5.0"
 encoding_rs = "0.8.28"
 encoding_rs_io = "0.1.7"
 flate2 = "1.0.22"
+# Add "tracing" feature to hyper once it stabilizes
 hyper = { version = "1.2", default-features = false }
 indicatif = "0.17"
 jsonxf = "1.1.0"
@@ -51,6 +52,11 @@ url = "2.2.2"
 ruzstd = { version = "0.7", default-features = false, features = ["std"]}
 env_logger = { version = "0.11.3", default-features = false, features = ["color", "auto-color", "humantime"] }
 log = "0.4.21"
+
+# Enable logging in transitive dependencies.
+# The rustls version number should be kept in sync with hyper/reqwest.
+rustls = { version = "0.23.14", optional = true, default-features = false, features = ["logging"] }
+tracing = { version = "0.1.41", default-features = false, features = ["log"] }
 
 [dependencies.reqwest]
 version = "0.12.3"
@@ -85,7 +91,7 @@ http-body-util = "0.1.1"
 [features]
 default = ["online-tests", "rustls", "network-interface"]
 native-tls = ["reqwest/native-tls", "reqwest/native-tls-alpn"]
-rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-webpki-roots", "reqwest/rustls-tls-native-roots"]
+rustls = ["reqwest/rustls-tls", "reqwest/rustls-tls-webpki-roots", "reqwest/rustls-tls-native-roots", "dep:rustls"]
 
 # To be used by platforms that don't support binding to interface via SO_BINDTODEVICE
 # Ideally, this would be auto-disabled on platforms that don't need it

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ fn main() {
     log::debug!("{args:#?}");
 
     let native_tls = args.native_tls;
+    let bin_name = args.bin_name.clone();
 
     match run(args) {
         Ok(exit_code) => {
@@ -80,7 +81,7 @@ fn main() {
         }
         Err(err) => {
             log::debug!("{err:#?}");
-            log::error!("{err:?}");
+            eprintln!("{bin_name}: error: {err:?}");
             let msg = err.root_cause().to_string();
             if native_tls && msg == "invalid minimum TLS version for backend" {
                 eprintln!();


### PR DESCRIPTION
Enable `rustls`'s `logging` feature to start emitting logs.

Enable the `tracing` crate's `log` feature to hook up the dependencies that log via that crate.

`hyper` can use `tracing` but it's currently unstable and locked behind `RUSTFLAGS='--cfg hyper_unstable_tracing'` so we shouldn't use it yet.

This partially addresses #389.

```console
$ RUST_LOG=trace/ALPN xh https://example.org
[0.495665s DEBUG rustls::client::hs] ALPN protocol is Some(b"h2")
[0.499526s TRACE hyper_util::client::legacy::client] ALPN negotiated h2, updating pool
HTTP/2.0 200 OK
[...]
$ RUST_LOG=rustls xh https://example.org
[0.288085s DEBUG rustls::client::hs] No cached session for DnsName("example.org")
[0.288657s DEBUG rustls::client::hs] Not resuming any session
[0.288767s TRACE rustls::client::hs] Sending ClientHello Message {
    version: TLSv1_0,
    payload: Handshake {
[...]
[0.698465s DEBUG rustls::client::hs] Using ciphersuite TLS13_AES_256_GCM_SHA384
[0.698508s DEBUG rustls::client::tls13] Not resuming
[0.698530s TRACE rustls::client::client_conn] EarlyData rejected
[0.699267s DEBUG rustls::client::tls13] TLS1.3 encrypted extensions: [Protocols([ProtocolName(6832)])]
[0.699342s DEBUG rustls::client::hs] ALPN protocol is Some(b"h2")
[0.699578s TRACE rustls::client::tls13] Server cert is
CertificateChain([CertificateDer(0x3082076e3082[...]
```

`native-tls` barely has any logging so we don't get much useful info from there yet.

-----

Additionally, print errors even if logs are getting filtered. Before:
```console
$ RUST_LOG=foobar xh ssh://example.org
[no output]
```
After:
```console
$ RUST_LOG=foobar xh ssh://example.org
xh: error: builder error for url (ssh://example.org)

Caused by:
    URL scheme is not allowed
```
This got confusing when debugging.