### PR TITLE
Support http over unix domain sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,6 +2523,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "form_urlencoded",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ dirs = "5.0"
 encoding_rs = "0.8.28"
 encoding_rs_io = "0.1.7"
 flate2 = "1.0.22"
+http = "1"
 # Add "tracing" feature to hyper once it stabilizes
 hyper = { version = "1.2", default-features = false }
+hyper-util = { version = "0.1", features = ["tokio"] }
 indicatif = "0.17"
 jsonxf = "1.1.0"
 memchr = "2.4.1"
@@ -47,6 +49,7 @@ serde_urlencoded = "0.7.0"
 supports-hyperlinks = "3.0.0"
 termcolor = "1.1.2"
 time = "0.3.16"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 unicode-width = "0.1.9"
 url = "2.2.2"
 ruzstd = { version = "0.7", default-features = false, features = ["std"]}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -347,6 +347,12 @@ Example: --print=Hb"
     #[clap(short = '6', long)]
     pub ipv6: bool,
 
+    /// Connect using a Unix domain socket.
+    ///
+    /// Example: --unix_socket=/var/run/temp.sock
+    #[clap(long, value_name = "FILE")]
+    pub unix_socket: Option<PathBuf>,
+
     /// Do not attempt to read stdin.
     ///
     /// This disables the default behaviour of reading the request body from stdin

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -299,6 +299,11 @@ pub fn translate(args: Cli) -> Result<Command> {
         cmd.arg(interface);
     };
 
+    if let Some(unix_socket) = args.unix_socket {
+        cmd.arg("--unix-socket");
+        cmd.arg(unix_socket);
+    }
+
     if !args.resolve.is_empty() {
         let port = url
             .port_or_known_default()

--- a/src/unix_socket.rs
+++ b/src/unix_socket.rs
@@ -1,0 +1,104 @@
+use anyhow::Result;
+use reqwest::blocking::{Request, Response};
+use reqwest::header::{HeaderValue, HOST};
+use std::path::PathBuf;
+use std::time::Instant;
+
+use crate::middleware::{Context, Middleware, ResponseMeta};
+use crate::utils::test_mode;
+
+pub struct UnixSocket {
+    rt: tokio::runtime::Runtime,
+    socket_path: PathBuf,
+}
+
+impl UnixSocket {
+    pub fn new(socket_path: PathBuf) -> Self {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        Self { rt, socket_path }
+    }
+
+    pub fn execute(&self, request: Request) -> Result<Response> {
+        self.rt.block_on(async {
+            // TODO: Support named pipes by replacing tokio::net::UnixStream::connect(..) with:
+            //
+            // use std::time::Duration;
+            // use tokio::net::windows::named_pipe;
+            // use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+            //
+            // let stream = loop {
+            //     match named_pipe::ClientOptions::new().open(r"\\.\pipe\docker_engine") {
+            //         Ok(client) => break client,
+            //         Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => (),
+            //         Err(e) => return Err(e)?,
+            //     }
+            //
+            //     tokio::time::sleep(Duration::from_millis(50)).await;
+            // };
+            let stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+
+            let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
+                .title_case_headers(true)
+                .handshake(hyper_util::rt::TokioIo::new(stream))
+                .await?;
+
+            tokio::task::spawn(async move {
+                if let Err(err) = conn.await {
+                    log::error!("Connection failed: {:?}", err);
+                }
+            });
+
+            // TODO: figure out how to support cookies.
+            // TODO: don't ignore value from --timeout option
+            let http_request = into_async_request(request)?;
+            let response = sender.send_request(http_request.try_into()?).await?;
+
+            Ok(Response::from(response.map(|b| reqwest::Body::wrap(b))))
+        })
+    }
+}
+
+impl Middleware for UnixSocket {
+    fn handle(&mut self, mut _ctx: Context, request: Request) -> Result<Response> {
+        let starting_time = Instant::now();
+        let mut response = self.execute(request)?;
+        response.extensions_mut().insert(ResponseMeta {
+            request_duration: starting_time.elapsed(),
+            content_download_duration: None,
+        });
+        Ok(response)
+    }
+}
+
+fn into_async_request(mut request: Request) -> Result<http::Request<reqwest::Body>> {
+    let mut http_request = http::Request::builder()
+        .version(request.version())
+        .method(request.method())
+        .uri(request.url().as_str())
+        .body(reqwest::Body::default())?;
+
+    *http_request.headers_mut() = request.headers_mut().clone();
+
+    if let Some(host) = request.url().host_str() {
+        http_request.headers_mut().entry(HOST).or_insert_with(|| {
+            if test_mode() {
+                HeaderValue::from_str("http.mock")
+            } else if let Some(port) = request.url().port() {
+                HeaderValue::from_str(&format!("{}:{}", host, port))
+            } else {
+                HeaderValue::from_str(host)
+            }
+            .expect("hostname should already be validated/parsed")
+        });
+    }
+
+    if let Some(body) = request.body_mut().as_mut() {
+        *http_request.body_mut() = reqwest::Body::from(body.buffer()?.to_owned());
+    }
+
+    Ok(http_request)
+}

--- a/tests/cases/http_unix.rs
+++ b/tests/cases/http_unix.rs
@@ -1,0 +1,75 @@
+use indoc::indoc;
+
+use crate::prelude::*;
+
+#[test]
+fn json_post() {
+    let server = server::http_unix(|req| async move {
+        assert_eq!(req.method(), "POST");
+        assert_eq!(req.headers()["Content-Type"], "application/json");
+        assert_eq!(req.body_as_string().await, "{\"foo\":\"bar\"}");
+
+        hyper::Response::builder()
+            .header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(r#"{"status":"ok"}"#.into())
+            .unwrap()
+    });
+
+    get_command()
+        .arg("--print=b")
+        .arg("--pretty=format")
+        .arg("post")
+        .arg("http://example.com")
+        .arg(format!(
+            "--unix-socket={}",
+            server.socket_path().to_string_lossy()
+        ))
+        .arg("foo=bar")
+        .assert()
+        .stdout(indoc! {r#"
+            {
+                "status": "ok"
+            }
+
+
+        "#});
+}
+
+#[test]
+fn redirects_stay_on_same_server() {
+    let server = server::http_unix(|req| async move {
+        match dbg!(req.uri().to_string().as_str()) {
+            "http://example.com/first_page" => hyper::Response::builder()
+                .status(302)
+                .header("Date", "N/A")
+                .header("Location", "http://localhost:8000/second_page")
+                .body("redirecting...".into())
+                .unwrap(),
+            "http://localhost:8000/second_page" => hyper::Response::builder()
+                .status(302)
+                .header("Date", "N/A")
+                .header("Location", "/third_page")
+                .body("redirecting...".into())
+                .unwrap(),
+            "http://localhost:8000/third_page" => hyper::Response::builder()
+                .header("Date", "N/A")
+                .body("final destination".into())
+                .unwrap(),
+            _ => panic!("unknown path"),
+        }
+    });
+
+    get_command()
+        .arg("http://example.com/first_page")
+        .arg(format!(
+            "--unix-socket={}",
+            server.socket_path().to_string_lossy()
+        ))
+        .arg("--follow")
+        .assert()
+        .success();
+
+    server.assert_hits(3);
+}
+
+// TODO: add tests for cookies

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -1,1 +1,2 @@
+mod http_unix;
 mod logging;


### PR DESCRIPTION
Adds a `--unix-socket` option similar to cURL for binding to a Unix domain socket. When used, all requests, including redirects, will go through the specified Unix socket.

To make existing blocking requests compatible with hyper, we are buffering the request body. Since we already do this for redirects, I thought this should be a problem for now.

Lastly, I have slightly refactored `ClientWithMiddleware` to ensure it doesn't get out of scope along with its middlewares before responses have been fully printed. Otherwise, `tokio::runtime` in `UnixSocket` is dropped and response will not be printed.

#### Resources used:
- https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/barbara_tries_unix_socket.html
- https://github.com/softprops/hyperlocal/issues/64#issue-2008021577

Resolves #230