### PR TITLE
Security update: upgrade to ruzstd v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
 
 [[package]]
 name = "ryu"


### PR DESCRIPTION
Security update
RUSTSEC-2024-0400: ruzstd uninit and out-of-bounds memory reads 
KillingSpark/zstd-rs#75