### PR TITLE
Generate man page with reproducible timestamp

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -182,7 +182,12 @@ fn generate_manpages(app: &mut clap::Command) {
     let mut manpage = MAN_TEMPLATE.to_string();
 
     let current_date = {
-        let (year, month, day) = DateTime::now_utc().date().to_calendar_date();
+        // https://reproducible-builds.org/docs/source-date-epoch/
+        let now = match std::env::var("SOURCE_DATE_EPOCH") {
+            Ok(val) => DateTime::from_unix_timestamp(val.parse::<i64>().unwrap()).unwrap(),
+            Err(_) => DateTime::now_utc(),
+        };
+        let (year, month, day) = now.date().to_calendar_date();
         format!("{}-{:02}-{:02}", year, u8::from(month), day)
     };
 


### PR DESCRIPTION
As [reported in Debian](https://bugs.debian.org/1092917), current generation code uses the time point it executed at as the date of the man page, so a build on e.g. 2025-01-20 would differ from a build on 2025-01-19, even if the content hasn't actually changed. This changes it to use the `SOURCE_DATE_EPOCH` environment variable if present, as explained in the [Reproducible Builds docs](https://reproducible-builds.org/docs/source-date-epoch/).