### PR TITLE
Set RUST_BACKTRACE=0 in feature tests

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -92,6 +92,7 @@ fn get_base_command() -> Command {
     cmd.env("XH_CONFIG_DIR", "");
     #[cfg(target_os = "windows")]
     cmd.env("XH_TEST_MODE_WIN_HOME_DIR", "");
+    cmd.env("RUST_BACKTRACE", "0");
     cmd
 }
 


### PR DESCRIPTION
If `RUST_BACKTRACE=1` was set outside the test runner, e.g. `RUST_BACKTRACE=1 cargo test`, this propagated to the test binary and changed error outputs.

Interestingly this only affected `nested_json_type_error`.

Resolves #406.