### PR TITLE
Add --bypass-proxy argument to ignore proxy for hosts or IP addresses.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -298,9 +298,14 @@ Example: --print=Hb"
 
     /// Comma-separated list of hosts for which not to use a proxy, if one is specified.
     ///
-    /// - A '*' matches all hosts, and effectively disables proxies altogether.
-    /// - IP addresses are allowed, as are subnets (in CIDR notation, i.e.: '127.0.0.0/8').
+    /// - A "*" matches all hosts, and effectively disables proxies altogether.
+    ///
+    /// - IP addresses are allowed, as are subnets (in CIDR notation, i.e.: "127.0.0.0/8").
+    ///
     /// - Any other entry in the list is assumed to be a hostname.
+    ///
+    /// The environment variable "NO_PROXY"/"no_proxy" can also be used, but its completely ignored
+    /// if --disable-proxy-for is passed.
     #[clap(long, value_name = "no-proxy-list", value_delimiter = ',')]
     pub disable_proxy_for: Vec<DisableProxyFor>,
 
@@ -1114,7 +1119,10 @@ impl Proxy {
             noproxy_comma_delimited.push_str(",0.0.0.0/0,::/0");
         }
 
-        Ok(proxy.no_proxy(reqwest::NoProxy::from_string(&noproxy_comma_delimited)))
+        Ok(proxy.no_proxy(
+            reqwest::NoProxy::from_string(&noproxy_comma_delimited)
+                .or_else(reqwest::NoProxy::from_env),
+        ))
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1110,6 +1110,7 @@ impl Proxy {
         let mut noproxy_comma_delimited = disable_proxy_for.join(",");
         if disable_proxy_for.contains(&"*".into()) {
             // reqwest's NoProxy wildcard doesn't apply to IP addresses, while curl's does
+            // See: https://github.com/seanmonstar/reqwest/issues/2579
             noproxy_comma_delimited.push_str(",0.0.0.0/0,::/0");
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,7 @@ fn run(args: Cli) -> Result<i32> {
     }
 
     for proxy in args.proxy.into_iter().rev() {
-        client = client.proxy(proxy.into_reqwest_proxy(&args.noproxy)?);
+        client = client.proxy(proxy.into_reqwest_proxy(&args.disable_proxy_for)?);
     }
 
     client = match args.http_version {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use utils::reason_phrase;
 
 use crate::auth::{Auth, DigestAuthMiddleware};
 use crate::buffer::Buffer;
-use crate::cli::{Cli, FormatOptions, HttpVersion, Print, Proxy, Verify};
+use crate::cli::{Cli, FormatOptions, HttpVersion, Print, Verify};
 use crate::download::{download_file, get_file_size};
 use crate::middleware::ClientWithMiddleware;
 use crate::printer::Printer;
@@ -274,11 +274,7 @@ fn run(args: Cli) -> Result<i32> {
     }
 
     for proxy in args.proxy.into_iter().rev() {
-        client = client.proxy(match proxy {
-            Proxy::Http(url) => reqwest::Proxy::http(url),
-            Proxy::Https(url) => reqwest::Proxy::https(url),
-            Proxy::All(url) => reqwest::Proxy::all(url),
-        }?);
+        client = client.proxy(proxy.into_reqwest_proxy(&args.noproxy)?);
     }
 
     client = match args.http_version {

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -233,9 +233,9 @@ pub fn translate(args: Cli) -> Result<Command> {
             }
         }
     }
-    if !args.noproxy.is_empty() {
+    if !args.disable_proxy_for.is_empty() {
         cmd.arg("--noproxy");
-        cmd.arg(args.noproxy.join(","));
+        cmd.arg(args.disable_proxy_for.join(","));
     }
     if let Some(timeout) = args.timeout.and_then(|t| t.as_duration()) {
         cmd.arg("--max-time");

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -233,6 +233,10 @@ pub fn translate(args: Cli) -> Result<Command> {
             }
         }
     }
+    if !args.noproxy.is_empty() {
+        cmd.arg("--noproxy");
+        cmd.arg(args.noproxy.join(","));
+    }
     if let Some(timeout) = args.timeout.and_then(|t| t.as_duration()) {
         cmd.arg("--max-time");
         cmd.arg(timeout.as_secs_f64().to_string());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1136,11 +1136,11 @@ fn proxy_multiple_valid_proxies() {
     cmd.assert().success();
 }
 
-enum NoProxyTestType {
+enum DisableProxyForTestType {
     ProxyUsed,
     ProxyNotUsed,
 }
-fn noproxy_test(noproxy_arg: &str, test_type: NoProxyTestType) {
+fn disable_proxy_for_test(disable_proxy_for_arg: &str, test_type: DisableProxyForTestType) {
     let mut proxy_server = server::http(|_| async move {
         hyper::Response::builder()
             .status(200)
@@ -1156,13 +1156,13 @@ fn noproxy_test(noproxy_arg: &str, test_type: NoProxyTestType) {
 
     get_command()
         .arg(format!("--proxy=http:{}", proxy_server.base_url()))
-        .arg(format!("--noproxy={}", noproxy_arg))
+        .arg(format!("--disable-proxy-for={}", disable_proxy_for_arg))
         .arg("GET")
         .arg(actual_server.base_url().as_str())
         .assert()
         .success();
 
-    if let NoProxyTestType::ProxyNotUsed = test_type {
+    if let DisableProxyForTestType::ProxyNotUsed = test_type {
         proxy_server.disable_hit_checks();
         proxy_server.assert_hits(0);
         actual_server.assert_hits(1);
@@ -1174,53 +1174,59 @@ fn noproxy_test(noproxy_arg: &str, test_type: NoProxyTestType) {
 }
 
 #[test]
-fn noproxy_wildcard() {
-    noproxy_test("*", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_wildcard() {
+    disable_proxy_for_test("*", DisableProxyForTestType::ProxyNotUsed);
 }
 
 #[test]
-fn noproxy_ip() {
-    noproxy_test("127.0.0.1", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_ip() {
+    disable_proxy_for_test("127.0.0.1", DisableProxyForTestType::ProxyNotUsed);
 }
 
 #[test]
-fn noproxy_ip_cidr() {
-    noproxy_test("127.0.0.0/8", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_ip_cidr() {
+    disable_proxy_for_test("127.0.0.0/8", DisableProxyForTestType::ProxyNotUsed);
 }
 
 #[test]
-fn noproxy_multiple() {
-    noproxy_test("127.0.0.2,127.0.0.1", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_multiple() {
+    disable_proxy_for_test("127.0.0.2,127.0.0.1", DisableProxyForTestType::ProxyNotUsed);
 }
 
 #[test]
-fn noproxy_whitespace() {
-    noproxy_test("example.test, 127.0.0.1", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_whitespace() {
+    disable_proxy_for_test(
+        "example.test, 127.0.0.1",
+        DisableProxyForTestType::ProxyNotUsed,
+    );
 }
 
 #[test]
-fn noproxy_whitespace_wildcard() {
-    noproxy_test("example.test, *", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_whitespace_wildcard() {
+    disable_proxy_for_test("example.test, *", DisableProxyForTestType::ProxyNotUsed);
 }
 
 #[test]
-fn noproxy_whitespace_ip() {
-    noproxy_test("127.0.0.2, 127.0.0.1", NoProxyTestType::ProxyNotUsed);
+fn disable_proxy_for_whitespace_ip() {
+    disable_proxy_for_test(
+        "127.0.0.2, 127.0.0.1",
+        DisableProxyForTestType::ProxyNotUsed,
+    );
 }
 
 #[test]
-fn noproxy_other_host() {
-    noproxy_test("example.test", NoProxyTestType::ProxyUsed);
+fn disable_proxy_for_other_host() {
+    disable_proxy_for_test("example.test", DisableProxyForTestType::ProxyUsed);
 }
 
 #[test]
-fn noproxy_other_ip() {
-    noproxy_test("127.0.0.2", NoProxyTestType::ProxyUsed);
+fn disable_proxy_for_other_ip() {
+    disable_proxy_for_test("127.0.0.2", DisableProxyForTestType::ProxyUsed);
 }
 
 #[test]
-fn noproxy_other_ip_cidr() {
-    noproxy_test("127.0.1.0/24", NoProxyTestType::ProxyUsed);
+fn disable_proxy_for_other_ip_cidr() {
+    disable_proxy_for_test("127.0.1.0/24", DisableProxyForTestType::ProxyUsed);
 }
 
 // temporarily disabled for builds not using rustls


### PR DESCRIPTION
I saw #296 as a _good first issue_ and thought I'd have a go at it.

A few things to note:
- I named the argument the same as curl's (`--noproxy`), as that seems to be what you were aiming for. This could potentially be confusing for users, as it's similar to `--no-proxy`, which undoes any `--proxy` arguments.
- reqwest's `NoProxy`'s applies a wildcard (`*`) only to hostnames, not IP addresses. curl does both. So there's a little workaround to implicitly add IPv4 and IPv6 full ranges (respectively `0.0.0.0/0` and `::/0`).
- I wanted to add tests for IPv6 and hostnames, but didn't see a way to do this easily: IPv6 would require testing on a host that has an IPv6 interface (not sure `lo` has that by default), and for hostnames, I thought I could use `--resolve`, but that turns the hostname into an IP address, so the hostname never reaches reqwest. If needed, I can take a closer look to see if I can add these tests.