### PR TITLE
Support http over unix domain sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,9 +1771,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ percent-encoding = "2.3.1"
 sanitize-filename = "0.6.0"
 
 [dependencies.reqwest]
-version = "0.12.22"
+version = "0.12.23"
 default-features = false
 features = ["json", "multipart", "blocking", "socks", "cookies", "http2", "macos-system-configuration"]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -358,6 +358,12 @@ Example: --print=Hb"
     #[clap(short = '6', long)]
     pub ipv6: bool,
 
+    /// Connect using a Unix domain socket.
+    ///
+    /// Example: xh :/index.html --unix-socket=/var/run/temp.sock
+    #[clap(long, value_name = "FILE")]
+    pub unix_socket: Option<PathBuf>,
+
     /// Do not attempt to read stdin.
     ///
     /// This disables the default behaviour of reading the request body from stdin

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1222,7 +1222,7 @@ pub enum Generate {
 /// BE instead.
 fn parse_encoding(encoding: &str) -> anyhow::Result<&'static Encoding> {
     let normalized_encoding = encoding.to_lowercase().replace(
-        |c: char| (!c.is_alphanumeric() && c != '_' && c != '-' && c != ':'),
+        |c: char| !c.is_alphanumeric() && c != '_' && c != '-' && c != ':',
         "",
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,19 @@ fn run(args: Cli) -> Result<ExitCode> {
         };
     }
 
+    if let Some(socket_path) = args.unix_socket {
+        #[cfg(not(unix))]
+        {
+            return Err(anyhow::anyhow!(
+                "Unix sockets is not supported on this platform"
+            ));
+        }
+        #[cfg(unix)]
+        {
+            client = client.unix_socket(socket_path);
+        }
+    }
+
     for resolve in args.resolve {
         client = client.resolve(&resolve.domain, SocketAddr::new(resolve.addr, 0));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,17 +364,16 @@ fn run(args: Cli) -> Result<ExitCode> {
         };
     }
 
+    #[cfg(unix)]
     if let Some(socket_path) = args.unix_socket {
-        #[cfg(not(unix))]
-        {
-            return Err(anyhow::anyhow!(
-                "Unix sockets is not supported on this platform"
-            ));
-        }
-        #[cfg(unix)]
-        {
-            client = client.unix_socket(socket_path);
-        }
+        client = client.unix_socket(socket_path);
+    }
+
+    #[cfg(not(unix))]
+    if args.unix_socket.is_some() {
+        return Err(anyhow::anyhow!(
+            "--unix-socket is not supported on this platform"
+        ));
     }
 
     for resolve in args.resolve {

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -302,6 +302,11 @@ pub fn translate(args: Cli) -> Result<Command> {
         cmd.arg(interface);
     };
 
+    if let Some(unix_socket) = args.unix_socket {
+        cmd.arg("--unix-socket");
+        cmd.arg(unix_socket);
+    }
+
     if !args.resolve.is_empty() {
         let port = url
             .port_or_known_default()

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -1,3 +1,4 @@
 mod compress_request_body;
 mod download;
 mod logging;
+mod unix_socket;

--- a/tests/cases/unix_socket.rs
+++ b/tests/cases/unix_socket.rs
@@ -13,9 +13,7 @@ fn error_on_unsupported_platform() {
         .arg(":/index.html")
         .assert()
         .failure()
-        .stderr(contains(
-            "HTTP over Unix domain sockets is not supported on this platform",
-        ));
+        .stderr(contains("--unix-socket is not supported on this platform"));
 }
 
 #[cfg(unix)]

--- a/tests/cases/unix_socket.rs
+++ b/tests/cases/unix_socket.rs
@@ -1,0 +1,134 @@
+#[cfg(unix)]
+use indoc::indoc;
+
+use crate::prelude::*;
+
+#[cfg(not(unix))]
+#[test]
+fn error_on_unsupported_platform() {
+    use predicates::str::contains;
+
+    get_command()
+        .arg(format!("--unix-socket=/tmp/missing.sock",))
+        .arg(":/index.html")
+        .assert()
+        .failure()
+        .stderr(contains(
+            "HTTP over Unix domain sockets is not supported on this platform",
+        ));
+}
+
+#[cfg(unix)]
+#[test]
+fn json_post() {
+    let server = server::http_unix(|req| async move {
+        assert_eq!(req.method(), "POST");
+        assert_eq!(req.headers()["Content-Type"], "application/json");
+        assert_eq!(req.body_as_string().await, "{\"foo\":\"bar\"}");
+
+        hyper::Response::builder()
+            .header(hyper::header::CONTENT_TYPE, "application/json")
+            .body(r#"{"status":"ok"}"#.into())
+            .unwrap()
+    });
+
+    get_command()
+        .arg("--print=b")
+        .arg("--pretty=format")
+        .arg("post")
+        .arg("http://example.com")
+        .arg(format!(
+            "--unix-socket={}",
+            server.socket_path().to_string_lossy()
+        ))
+        .arg("foo=bar")
+        .assert()
+        .stdout(indoc! {r#"
+            {
+                "status": "ok"
+            }
+
+
+        "#});
+}
+
+#[cfg(unix)]
+#[test]
+fn redirects_stay_on_same_server() {
+    let server = server::http_unix(|req| async move {
+        match req.uri().to_string().as_str() {
+            "/first_page" => hyper::Response::builder()
+                .status(302)
+                .header("Date", "N/A")
+                .header("Location", "http://localhost:8000/second_page")
+                .body("redirecting...".into())
+                .unwrap(),
+            "/second_page" => hyper::Response::builder()
+                .status(302)
+                .header("Date", "N/A")
+                .header("Location", "/third_page")
+                .body("redirecting...".into())
+                .unwrap(),
+            "/third_page" => hyper::Response::builder()
+                .header("Date", "N/A")
+                .body("final destination".into())
+                .unwrap(),
+            _ => panic!("unknown path"),
+        }
+    });
+
+    get_command()
+        .arg("http://example.com/first_page")
+        .arg(format!(
+            "--unix-socket={}",
+            server.socket_path().to_string_lossy()
+        ))
+        .arg("--follow")
+        .arg("--verbose")
+        .arg("--all")
+        .assert()
+        .stdout(indoc! {r#"
+            GET /first_page HTTP/1.1
+            Accept: */*
+            Accept-Encoding: gzip, deflate, br, zstd
+            Connection: keep-alive
+            Host: http.mock
+            User-Agent: xh/0.0.0 (test mode)
+
+            HTTP/1.1 302 Found
+            Content-Length: 14
+            Date: N/A
+            Location: http://localhost:8000/second_page
+
+            redirecting...
+
+            GET /second_page HTTP/1.1
+            Accept: */*
+            Accept-Encoding: gzip, deflate, br, zstd
+            Connection: keep-alive
+            Host: http.mock
+            User-Agent: xh/0.0.0 (test mode)
+
+            HTTP/1.1 302 Found
+            Content-Length: 14
+            Date: N/A
+            Location: /third_page
+
+            redirecting...
+
+            GET /third_page HTTP/1.1
+            Accept: */*
+            Accept-Encoding: gzip, deflate, br, zstd
+            Connection: keep-alive
+            Host: http.mock
+            User-Agent: xh/0.0.0 (test mode)
+
+            HTTP/1.1 200 OK
+            Content-Length: 17
+            Date: N/A
+
+            final destination
+        "#});
+
+    server.assert_hits(3);
+}

--- a/tests/cases/unix_socket.rs
+++ b/tests/cases/unix_socket.rs
@@ -9,7 +9,7 @@ fn error_on_unsupported_platform() {
     use predicates::str::contains;
 
     get_command()
-        .arg(format!("--unix-socket=/tmp/missing.sock",))
+        .arg("--unix-socket=/tmp/missing.sock")
         .arg(":/index.html")
         .assert()
         .failure()

--- a/tests/server/mod.rs
+++ b/tests/server/mod.rs
@@ -2,7 +2,7 @@
 // with some slight tweaks
 use std::convert::Infallible;
 use std::future::Future;
-use std::net;
+use std::path::PathBuf;
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -12,14 +12,22 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use tokio::net::{TcpListener, UnixListener};
 use tokio::runtime;
 use tokio::sync::oneshot;
 
 type Body = Full<Bytes>;
 type Builder = hyper_util::server::conn::auto::Builder<hyper_util::rt::TokioExecutor>;
 
+enum Listener {
+    TcpListener(tokio::net::TcpListener),
+    #[cfg(unix)]
+    UnixListener(tempfile::NamedTempFile<tokio::net::UnixListener>),
+}
+
 pub struct Server {
-    addr: net::SocketAddr,
+    listener: Arc<Listener>,
     panic_rx: std_mpsc::Receiver<()>,
     successful_hits: Arc<Mutex<u8>>,
     total_hits: Arc<Mutex<u8>>,
@@ -29,19 +37,49 @@ pub struct Server {
 
 impl Server {
     pub fn base_url(&self) -> String {
-        format!("http://{}", self.addr)
+        match &*self.listener {
+            Listener::TcpListener(l) => format!("http://{}", l.local_addr().unwrap()),
+            #[cfg(unix)]
+            _ => panic!("no base_url for unix server"),
+        }
     }
 
     pub fn url(&self, path: &str) -> String {
-        format!("http://{}{}", self.addr, path)
+        match &*self.listener {
+            Listener::TcpListener(l) => format!("http://{}{}", l.local_addr().unwrap(), path),
+            #[cfg(unix)]
+            _ => panic!("no url for unix server"),
+        }
     }
 
     pub fn host(&self) -> String {
-        String::from("127.0.0.1")
+        match &*self.listener {
+            Listener::TcpListener(_) => String::from("127.0.0.1"),
+            #[cfg(unix)]
+            _ => panic!("no host for unix server"),
+        }
+    }
+
+    #[cfg(unix)]
+    pub fn socket_path(&self) -> PathBuf {
+        match &*self.listener {
+            Listener::UnixListener(l) => l
+                .as_file()
+                .local_addr()
+                .unwrap()
+                .as_pathname()
+                .unwrap()
+                .to_path_buf(),
+            _ => panic!("no socket_path for tcp server"),
+        }
     }
 
     pub fn port(&self) -> u16 {
-        self.addr.port()
+        match &*self.listener {
+            Listener::TcpListener(l) => l.local_addr().unwrap().port(),
+            #[cfg(unix)]
+            _ => panic!("no port for unix server"),
+        }
     }
 
     pub fn assert_hits(&self, hits: u8) {
@@ -88,13 +126,22 @@ where
     F: Fn(Request<hyper::body::Incoming>) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Response<Body>> + Send + 'static,
 {
-    http_inner(Arc::new(move |req| Box::new(Box::pin(func(req)))))
+    http_inner(Arc::new(move |req| Box::new(Box::pin(func(req)))), false)
+}
+
+#[cfg(unix)]
+pub fn http_unix<F, Fut>(func: F) -> Server
+where
+    F: Fn(Request<hyper::body::Incoming>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Response<Body>> + Send + 'static,
+{
+    http_inner(Arc::new(move |req| Box::new(Box::pin(func(req)))), true)
 }
 
 type Serv = dyn Fn(Request<hyper::body::Incoming>) -> Box<ServFut> + Send + Sync;
 type ServFut = dyn Future<Output = Response<Body>> + Send + Unpin;
 
-fn http_inner(func: Arc<Serv>) -> Server {
+fn http_inner(func: Arc<Serv>, use_unix_socket: bool) -> Server {
     // Spawn new runtime in thread to prevent reactor execution context conflict
     thread::spawn(move || {
         let rt = runtime::Builder::new_current_thread()
@@ -103,12 +150,27 @@ fn http_inner(func: Arc<Serv>) -> Server {
             .expect("new rt");
         let successful_hits = Arc::new(Mutex::new(0));
         let total_hits = Arc::new(Mutex::new(0));
-        let listener = rt.block_on(async move {
-            tokio::net::TcpListener::bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
-                .await
-                .unwrap()
-        });
-        let addr = listener.local_addr().unwrap();
+
+        let listener = Arc::new(rt.block_on(async move {
+            if use_unix_socket {
+                #[cfg(not(unix))]
+                {
+                    panic!("unix server not supported")
+                }
+                #[cfg(unix)]
+                {
+                    tempfile::Builder::new()
+                        .make(|path| UnixListener::bind(path))
+                        .map(Listener::UnixListener)
+                        .unwrap()
+                }
+            } else {
+                TcpListener::bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                    .await
+                    .map(Listener::TcpListener)
+                    .unwrap()
+            }
+        }));
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let (panic_tx, panic_rx) = std_mpsc::channel();
@@ -120,6 +182,7 @@ fn http_inner(func: Arc<Serv>) -> Server {
         {
             let successful_hits = successful_hits.clone();
             let total_hits = total_hits.clone();
+            let listener = listener.clone();
             thread::Builder::new()
                 .name(thread_name)
                 .spawn(move || {
@@ -144,14 +207,25 @@ fn http_inner(func: Arc<Serv>) -> Server {
                                 })
                             };
 
-                            let (io, _) = listener.accept().await.unwrap();
-
                             let builder = builder.clone();
-                            tokio::spawn(async move {
-                                let _ = builder
-                                    .serve_connection(hyper_util::rt::TokioIo::new(io), svc)
-                                    .await;
-                            });
+
+                            match &*listener {
+                                Listener::TcpListener(listener) => {
+                                    let (io, _) = listener.accept().await.unwrap();
+                                    tokio::spawn(async move {
+                                        let _ =
+                                            builder.serve_connection(TokioIo::new(io), svc).await;
+                                    });
+                                }
+                                #[cfg(unix)]
+                                Listener::UnixListener(listener) => {
+                                    let (io, _) = listener.as_file().accept().await.unwrap();
+                                    tokio::spawn(async move {
+                                        let _ =
+                                            builder.serve_connection(TokioIo::new(io), svc).await;
+                                    });
+                                }
+                            };
                         }
                     });
                     let _ = rt.block_on(shutdown_rx);
@@ -161,7 +235,7 @@ fn http_inner(func: Arc<Serv>) -> Server {
                 .expect("thread spawn");
         }
         Server {
-            addr,
+            listener,
             panic_rx,
             shutdown_tx: Some(shutdown_tx),
             successful_hits,

--- a/tests/server/mod.rs
+++ b/tests/server/mod.rs
@@ -2,7 +2,6 @@
 // with some slight tweaks
 use std::convert::Infallible;
 use std::future::Future;
-use std::path::PathBuf;
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -13,7 +12,6 @@ use hyper::body::Bytes;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use tokio::net::{TcpListener, UnixListener};
 use tokio::runtime;
 use tokio::sync::oneshot;
 
@@ -61,7 +59,7 @@ impl Server {
     }
 
     #[cfg(unix)]
-    pub fn socket_path(&self) -> PathBuf {
+    pub fn socket_path(&self) -> std::path::PathBuf {
         match &*self.listener {
             Listener::UnixListener(l) => l
                 .as_file()
@@ -160,12 +158,12 @@ fn http_inner(func: Arc<Serv>, use_unix_socket: bool) -> Server {
                 #[cfg(unix)]
                 {
                     tempfile::Builder::new()
-                        .make(|path| UnixListener::bind(path))
+                        .make(|path| tokio::net::UnixListener::bind(path))
                         .map(Listener::UnixListener)
                         .unwrap()
                 }
             } else {
-                TcpListener::bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+                tokio::net::TcpListener::bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
                     .await
                     .map(Listener::TcpListener)
                     .unwrap()


### PR DESCRIPTION
Adds `--unix-socket` option to route all requests, including redirects, through the specified Unix socket.

See previous attempt at https://github.com/ducaale/xh/pull/392

Resolves https://github.com/ducaale/xh/issues/230