### PR TITLE
Use latest macOS runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,10 @@ jobs:
             flags: --features=http3
             rustflags: --cfg reqwest_unstable
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             flags: --features=native-tls
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-latest
             flags: --features=native-tls
           - target: x86_64-pc-windows-msvc
             os: windows-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,10 @@ jobs:
             os: ubuntu-latest
             flags: --no-default-features --features=native-tls,online-tests # disables rustls
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
             flags: --features=native-tls
           - target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-latest
             flags: --features=native-tls
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -70,10 +70,10 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             flags: --features=native-tls
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
             flags: --features=native-tls
           - os: windows-latest


### PR DESCRIPTION
Here is the deprecation notice sent by Github:

> The macOS 13 runner image will be retired by December 4th, 2025. To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:
> 
>     November 4, 14:00 UTC - November 5, 00:00 UTC
>     November 11, 14:00 UTC - November 12, 00:00 UTC
>     November 18, 14:00 UTC - November 19, 00:00 UTC
>     November 25, 14:00 UTC - November 26, 00:00 UTC
> 
> This deprecation includes the following labels:
> 
>     macos-13
>     macos-13-large
>     macos-13-xlarge
> 
> #### What you need to do
> (Recommended) If your workflow is architecture agnostic, you can migrate to any of our arm64 labels:
> 
>     macos-15 or macos-latest
>     macos-14
>     macos-14-xlarge
>     macos-latest-xlarge or macos-15-xlarge
>
>...
>
> #### Notice of macOS x86_64 (Intel) architecture deprecation
> Apple has discontinued support for the x86_64 (Intel) architecture going forward. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027. You should begin migrating your workloads to arm64-based (Apple Silicon) runners as soon as possible to prepare for this eventual deprecation. 