### PR TITLE
Don't set content-type for empty --json requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ use hyper::header::CONTENT_ENCODING;
 use redirect::RedirectFollower;
 use reqwest::blocking::{Body as ReqwestBody, Client};
 use reqwest::header::{
-    ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_TYPE, COOKIE, HeaderValue, RANGE, USER_AGENT,
+    ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HeaderValue, RANGE,
+    USER_AGENT,
 };
 use reqwest::tls;
 use url::Host;
@@ -139,6 +140,7 @@ fn run(args: Cli) -> Result<ExitCode> {
     } else {
         args.request_items.body()?
     };
+    let explicit_empty_json_body = matches!(&body, Body::Json(body) if body.is_null() && args.json);
 
     let method = args.method.unwrap_or_else(|| body.pick_method());
     log::debug!("HTTP method: {method}");
@@ -423,6 +425,8 @@ fn run(args: Cli) -> Result<ExitCode> {
             }
         }
     }
+    let had_content_length_header = headers.contains_key(CONTENT_LENGTH);
+    let had_content_type_header = headers.contains_key(CONTENT_TYPE);
 
     let mut request = {
         let mut request_builder = client
@@ -464,9 +468,7 @@ fn run(args: Cli) -> Result<ExitCode> {
                         .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
                         .json(&body)
                 } else if args.json {
-                    request_builder
-                        .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
-                        .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE))
+                    request_builder.header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
                 } else {
                     // We're here because this is the default request type
                     // There's nothing to do
@@ -563,6 +565,15 @@ fn run(args: Cli) -> Result<ExitCode> {
         }
 
         let mut request = request_builder.headers(headers).build()?;
+
+        if explicit_empty_json_body {
+            if !had_content_length_header {
+                request.headers_mut().remove(CONTENT_LENGTH);
+            }
+            if !had_content_type_header {
+                request.headers_mut().remove(CONTENT_TYPE);
+            }
+        }
 
         if args.compress >= 1 {
             if request.headers().contains_key(CONTENT_ENCODING) {

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -444,7 +444,6 @@ pub fn translate(args: Cli) -> Result<Command> {
                 cmd.arg(json_string);
             }
             Body::Json(..) if args.json => {
-                cmd.header("content-type", JSON_CONTENT_TYPE);
                 cmd.header("accept", JSON_ACCEPT);
             }
             Body::Json(..) => {}
@@ -529,7 +528,7 @@ mod tests {
             ),
             (
                 "xh --json httpbin.org/post",
-                "curl http://httpbin.org/post -H 'content-type: application/json' -H 'accept: application/json, */*;q=0.5'",
+                "curl http://httpbin.org/post -H 'accept: application/json, */*;q=0.5'",
             ),
             (
                 "xh --form httpbin.org/post x@/dev/null",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1414,13 +1414,46 @@ fn unsupported_tls_version_rustls() {
 #[test]
 fn forced_json() {
     let server = server::http(|req| async move {
-        assert_eq!(req.headers()["content-type"], "application/json");
         assert_eq!(req.headers()["accept"], "application/json, */*;q=0.5");
+        assert!(req.headers().get("content-type").is_none());
+        assert!(req.headers().get("content-length").is_none());
+        assert_eq!(req.body_as_string().await, "");
         hyper::Response::default()
     });
 
     get_command()
         .args(["--json", &server.base_url()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn forced_json_offline_does_not_set_content_headers() {
+    get_command()
+        .args(["--offline", "--json", "post", ":"])
+        .assert()
+        .stdout(indoc! {r#"
+            POST / HTTP/1.1
+            Accept: application/json, */*;q=0.5
+            Accept-Encoding: gzip, deflate, br, zstd
+            Connection: keep-alive
+            Host: http.mock
+            User-Agent: xh/0.0.0 (test mode)
+
+        "#});
+}
+
+#[test]
+fn forced_json_preserves_manual_content_type() {
+    let server = server::http(|req| async move {
+        assert_eq!(req.headers()["content-type"], "text/plain");
+        assert_eq!(req.headers()["accept"], "application/json, */*;q=0.5");
+        assert_eq!(req.body_as_string().await, "");
+        hyper::Response::default()
+    });
+
+    get_command()
+        .args(["--json", &server.base_url(), "content-type:text/plain"])
         .assert()
         .success();
 }


### PR DESCRIPTION
Fixes #218

Before:
- `xh --offline --ignore-stdin --json post :` printed `Content-Type: application/json` even though the request had no body.
- `xh --curl --json http://httpbin.org/post` translated to curl with the same header.

After:
- Empty `--json` requests keep the JSON `Accept` header but no longer add `Content-Type` or `Content-Length` unless the user set them explicitly.

Validation:
- `cargo test forced_json -- --exact --nocapture`
- `cargo test forced_json_offline_does_not_set_content_headers -- --exact --nocapture`
- `cargo test forced_json_preserves_manual_content_type -- --exact --nocapture`
- `cargo test basic_json_post -- --exact --nocapture`
- `cargo test default_json_for_raw_body -- --exact --nocapture`
- `cargo test examples -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --tests -- -D warnings -A unknown-lints`
- `cargo run --quiet -- --offline --ignore-stdin --json post :`
- `cargo run --quiet -- --curl --json http://httpbin.org/post`
