### PR TITLE
fix: disable default fish file completion

### DIFF
--- a/completions/xh.fish
+++ b/completions/xh.fish
@@ -3,6 +3,7 @@ function __xh_complete_data
     string match -qr '^(?<prefix>.*@)(?<path>.*)' -- (commandline -ct)
     printf '%s\n' -- $prefix(__fish_complete_path $path)
 end
+complete -c xh -f
 complete -c xh -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__xh_complete_data)"
 
 complete -c xh -l raw -d 'Pass raw request data without extra processing' -r
@@ -20,8 +21,8 @@ complete -c xh -l response-mime -d 'Override the response mime type for coloring
 complete -c xh -s p -l print -d 'String specifying what the output should contain' -r
 complete -c xh -s P -l history-print -d 'The same as --print but applies only to intermediary requests/responses' -r
 complete -c xh -s o -l output -d 'Save output to FILE instead of stdout' -r -F
-complete -c xh -l session -d 'Create, or reuse and update a session' -r
-complete -c xh -l session-read-only -d 'Create or read a session without updating it from the request/response exchange' -r
+complete -c xh -l session -d 'Create, or reuse and update a session' -r -F
+complete -c xh -l session-read-only -d 'Create or read a session without updating it from the request/response exchange' -r -F
 complete -c xh -s A -l auth-type -d 'Specify the auth mechanism' -r -f -a "basic\t''
 bearer\t''
 digest\t''"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -234,11 +234,16 @@ Example: --print=Hb"
     ///
     /// Within a session, custom headers, auth credentials, as well as any cookies sent
     /// by the server persist between requests.
-    #[clap(long, value_name = "FILE")]
+    #[clap(long, value_name = "FILE", value_hint = clap::ValueHint::FilePath)]
     pub session: Option<OsString>,
 
     /// Create or read a session without updating it from the request/response exchange.
-    #[clap(long, value_name = "FILE", conflicts_with = "session")]
+    #[clap(
+        long,
+        value_name = "FILE",
+        conflicts_with = "session",
+        value_hint = clap::ValueHint::FilePath
+    )]
     pub session_read_only: Option<OsString>,
 
     #[clap(skip)]

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write};
 
 use clap_complete::Shell;
 use clap_complete_nushell::Nushell;
@@ -19,23 +19,9 @@ pub fn generate(bin_name: &str, generate: Generate) {
             clap_complete::generate(Shell::Elvish, &mut app, bin_name, &mut io::stdout());
         }
         Generate::CompleteFish => {
-            use std::io::Write;
-            let mut buf = Vec::new();
-            clap_complete::generate(Shell::Fish, &mut app, bin_name, &mut buf);
-            let mut stdout = io::stdout();
-            // Based on https://github.com/fish-shell/fish-shell/blob/1e61e6492db879ba6c32013f901d84b067ca22eb/share/completions/curl.fish#L1-L6
-            let preamble = format!(
-                r#"# Complete paths after @ in options:
-function __{bin_name}_complete_data
-    string match -qr '^(?<prefix>.*@)(?<path>.*)' -- (commandline -ct)
-    printf '%s\n' -- $prefix(__fish_complete_path $path)
-end
-complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{bin_name}_complete_data)"
-
-"#,
-            );
-            stdout.write_all(preamble.as_bytes()).unwrap();
-            stdout.write_all(&buf).unwrap();
+            io::stdout()
+                .write_all(&generate_fish_completion(bin_name))
+                .unwrap();
         }
         Generate::CompleteNushell => {
             clap_complete::generate(Nushell, &mut app, bin_name, &mut io::stdout());
@@ -50,6 +36,28 @@ complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{
             generate_manpages(&mut app);
         }
     }
+}
+
+fn generate_fish_completion(bin_name: &str) -> Vec<u8> {
+    let mut app = Cli::into_app();
+    let mut buf = fish_preamble(bin_name).into_bytes();
+    clap_complete::generate(Shell::Fish, &mut app, bin_name, &mut buf);
+    buf
+}
+
+// Based on https://github.com/fish-shell/fish-shell/blob/1e61e6492db879ba6c32013f901d84b067ca22eb/share/completions/curl.fish#L1-L6
+fn fish_preamble(bin_name: &str) -> String {
+    format!(
+        r#"# Complete paths after @ in options:
+function __{bin_name}_complete_data
+    string match -qr '^(?<prefix>.*@)(?<path>.*)' -- (commandline -ct)
+    printf '%s\n' -- $prefix(__fish_complete_path $path)
+end
+complete -c {bin_name} -f
+complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{bin_name}_complete_data)"
+
+"#,
+    )
 }
 
 fn generate_manpages(app: &mut clap::Command) {
@@ -213,4 +221,26 @@ fn generate_manpages(app: &mut clap::Command) {
     manpage = manpage.replace("{{options}}", options_roff.to_roff().trim());
 
     print!("{manpage}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_fish_completion;
+
+    #[test]
+    fn fish_completion_disables_default_file_completion() {
+        let completion = String::from_utf8(generate_fish_completion("xh")).unwrap();
+        assert!(completion.contains("complete -c xh -f\n"));
+    }
+
+    #[test]
+    fn fish_completion_keeps_session_file_completion() {
+        let completion = String::from_utf8(generate_fish_completion("xh")).unwrap();
+        assert!(completion.contains(
+            "complete -c xh -l session -d 'Create, or reuse and update a session' -r -F"
+        ));
+        assert!(completion.contains(
+            "complete -c xh -l session-read-only -d 'Create or read a session without updating it from the request/response exchange' -r -F"
+        ));
+    }
 }


### PR DESCRIPTION
Fixes #340.

## Before
Fish would suggest files for `xh <tab>` because the generated completion script never disabled Fish's default file completion.

Adding `complete -c xh -f` by itself would also remove path completion for `--session` and `--session-read-only`.

## After
- add `complete -c xh -f` to the generated Fish completion preamble
- mark the session file arguments with `ValueHint::FilePath` so their generated completions keep `-F`
- add a regression test that checks both behaviors

## Validation
- `cargo fmt --check`
- `cargo test --locked fish_completion -- --nocapture`
- Fish repro using `complete -C "xh "` and `complete -C "xh --session "`
- `cargo test --locked` still fails on current HEAD in this macOS environment in existing warning-format assertions (for example `check_status_warning`); I reproduced that in a clean clone before this change as well
