### PR TITLE
Generate man page as markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Options:
 Each option can be reset with a --no-OPTION argument.
 ```
 
-Run `xh help` for more detailed information.
+Run `xh help` or [`man xh`](/doc/xh.1.md) for more detailed information.
 
 ### Request Items
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -13,7 +13,7 @@
   cargo run --features=native-tls -- --generate complete-powershell > completions/_xh.ps1
   cargo run --features=native-tls -- --generate complete-zsh > completions/_xh
   cargo run --features=native-tls -- --generate man > doc/xh.1
-  cargo run --features=native-tls -- --generate markdown > doc/xh.1.md
+  cargo run --features=native-tls -- --generate man-markdown > doc/xh.1.md
   ```
 - Commit changes and push them to remote.
 - Add git tag e.g `git tag v0.9.0`.

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -13,6 +13,7 @@
   cargo run --features=native-tls -- --generate complete-powershell > completions/_xh.ps1
   cargo run --features=native-tls -- --generate complete-zsh > completions/_xh
   cargo run --features=native-tls -- --generate man > doc/xh.1
+  cargo run --features=native-tls -- --generate markdown > doc/xh.1.md
   ```
 - Commit changes and push them to remote.
 - Add git tag e.g `git tag v0.9.0`.

--- a/doc/md-template.md
+++ b/doc/md-template.md
@@ -1,0 +1,200 @@
+## NAME
+
+`xh` - Friendly and fast tool for sending HTTP requests
+
+## SYNOPSIS
+
+```
+xh [OPTIONS] [METHOD] URL [REQUEST_ITEM ...]
+```
+
+## DESCRIPTION
+
+**xh** is an HTTP client with a friendly command line interface. It strives to
+have readable output and easy-to-use options.
+
+xh is mostly compatible with HTTPie: see http(1).
+
+The `--curl` option can be used to print a curl(1) translation of the
+command instead of sending a request.
+
+## POSITIONAL ARGUMENTS
+
+- `[METHOD]`:
+  The HTTP method to use for the request.
+  
+  This defaults to GET, or to POST if the request contains a body.
+
+- `URL`:
+  The URL to request.
+
+  The URL scheme defaults to `http://` normally, or `https://` if
+  the program is invoked as `xhs`.
+
+  A leading colon works as shorthand for localhost. `:8000` is equivalent
+  to `localhost:8000`, and `:/path` is equivalent to `localhost/path`.
+
+- `[REQUEST_ITEM ...]`:
+
+  Optional key-value pairs to be included in the request.
+
+  The separator is used to determine the type:
+
+  - `key==value`:
+    Add a query string to the URL.
+
+  - `key=value`:
+    Add a JSON property (`--json`) or form field (`--form`) to the request body.
+
+  - `key:=value`:
+    Add a field with a literal JSON value to the request body.
+  
+    Example: `numbers:=[1,2,3] enabled:=true`
+
+  - `key@filename`:
+    Upload a file (requires `--form` or `--multipart`).
+  
+    To set the filename and mimetype, `;type=` and `;filename=` can be used respectively.
+  
+    Example: `pfp@ra.jpg;type=image/jpeg;filename=profile.jpg`
+
+  - `@filename`:
+    Use a file as the request body.
+
+  - `header:value`:
+    Add a header, e.g. `user-agent:foobar`
+
+  - `header:`:
+    Unset a header, e.g. `connection:`
+
+  - `header;`:
+    Add a header with an empty value.
+
+  An `@` prefix can be used to read a value from a file. For example: `x-api-key:@api-key.txt`.
+  
+  A backslash can be used to escape special characters, e.g. `weird\:key=value`.
+  
+  To construct a complex JSON object, the `REQUEST_ITEM`'s key can be set to a JSON path instead of a field name. For more information on this syntax, refer to https://httpie.io/docs/cli/nested-json.
+
+## OPTIONS
+
+Each `--OPTION` can be reset with a `--no-OPTION` argument.
+
+{{options}}
+
+## EXIT STATUS
+
+- `0`: Successful program execution.
+- `1`: Usage, syntax or network error.
+- `2`: Request timeout.
+- `3`: Unexpected HTTP 3xx Redirection.
+- `4`: HTTP 4xx Client Error.
+- `5`: HTTP 5xx Server Error.
+- `6`: Too many redirects.
+
+## ENVIRONMENT
+
+- `XH_CONFIG_DIR`:
+  Specifies where to look for config.json and named session data.
+  The default is `~/.config/xh` for Linux/macOS and `%APPDATA%\xh` for Windows.
+
+- `XH_HTTPIE_COMPAT_MODE`:
+  Enables the HTTPie Compatibility Mode. The only current difference is that
+  `--check-status` is not enabled by default. An alternative to setting this
+  environment variable is to rename the binary to either http or https.
+
+- `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`:
+  Sets a custom CA bundle path.
+
+- `ALL_PROXY=[protocol://]<host>[:port]`:
+  Sets the proxy server for all requests (unless overridden for a specific protocol).
+
+- `HTTP_PROXY=[protocol://]<host>[:port]`:
+  Sets the proxy server to use for HTTP.
+
+- `HTTPS_PROXY=[protocol://]<host>[:port]`:
+  Sets the proxy server to use for HTTPS.
+
+- `NO_PROXY`:
+  List of comma-separated hosts for which to ignore the other proxy environment variables. `*` matches all host names.
+
+- `NETRC`:
+  Location of the `.netrc` file.
+
+- `NO_COLOR`:
+  Disables output coloring. See <https://no-color.org>
+
+- `RUST_LOG`:
+  Configure low-level debug messages. See https://docs.rs/env_logger/0.11.3/env_logger/#enabling-logging
+
+## FILES
+
+- `~/.config/xh/config.json`:
+  xh configuration file. The only configurable option is `default_options`
+  which is a list of default shell arguments that gets passed to `xh`.
+  Example:
+
+  ```json
+  { "default_options": ["--native-tls", "--style=solarized"] }
+  ```
+
+- `~/.netrc`, `~/_netrc`:
+Auto-login information file.
+
+- `~/.config/xh/sessions`:
+Session data directory grouped by domain and port number.
+
+## EXAMPLES
+
+Send a GET request:
+```
+xh httpbin.org/json
+```
+
+Send a POST request with body `{"name": "ahmed", "age": 24}`:
+```
+xh httpbin.org/post name=ahmed age:=24
+```
+
+Send a GET request to http://httpbin.org/json?id=5&sort=true:
+```
+xh get httpbin.org/json id==5 sort==true
+```
+
+Send a GET request and include a header named `X-Api-Key` with value `12345`:
+```
+xh get Ihttpbin.org/json x-api-key:12345
+```
+
+Send a POST request with body read from stdin:
+```
+echo "[1, 2, 3]" | xh post httpbin.org/post
+```
+
+Send a PUT request and pipe the result to `less`:
+```
+xh put httpbin.org/put id:=49 age:=25 | less
+```
+
+Download and save to `res.json`:
+```
+xh -d httpbin.org/json -o res.jso\fR
+```
+
+Make a request with a custom user agent:
+```
+xh httpbin.org/get user-agent:foobar
+```
+
+Make an HTTPS request to https://example.com:
+```
+xhs example.com
+```
+
+## REPORTING BUGS
+xh's Github issues https://github.com/ducaale/xh/issues
+
+## SEE ALSO
+curl(1), http(1)
+
+HTTPie's online documentation https://httpie.io/docs/cli

--- a/doc/md-template.md
+++ b/doc/md-template.md
@@ -140,7 +140,7 @@ xh put httpbin.org/put id:=49 age:=25 | less
 
 Download and save to `res.json`:
 ```
-xh -d httpbin.org/json -o res.jso\fR
+xh -d httpbin.org/json -o res.json
 ```
 
 Make a request with a custom user agent:

--- a/doc/md-template.md
+++ b/doc/md-template.md
@@ -36,45 +36,7 @@ command instead of sending a request.
 
 - `[REQUEST_ITEM ...]`:
 
-  Optional key-value pairs to be included in the request.
-
-  The separator is used to determine the type:
-
-  - `key==value`:
-    Add a query string to the URL.
-
-  - `key=value`:
-    Add a JSON property (`--json`) or form field (`--form`) to the request body.
-
-  - `key:=value`:
-    Add a field with a literal JSON value to the request body.
-  
-    Example: `numbers:=[1,2,3] enabled:=true`
-
-  - `key@filename`:
-    Upload a file (requires `--form` or `--multipart`).
-  
-    To set the filename and mimetype, `;type=` and `;filename=` can be used respectively.
-  
-    Example: `pfp@ra.jpg;type=image/jpeg;filename=profile.jpg`
-
-  - `@filename`:
-    Use a file as the request body.
-
-  - `header:value`:
-    Add a header, e.g. `user-agent:foobar`
-
-  - `header:`:
-    Unset a header, e.g. `connection:`
-
-  - `header;`:
-    Add a header with an empty value.
-
-  An `@` prefix can be used to read a value from a file. For example: `x-api-key:@api-key.txt`.
-  
-  A backslash can be used to escape special characters, e.g. `weird\:key=value`.
-  
-  To construct a complex JSON object, the `REQUEST_ITEM`'s key can be set to a JSON path instead of a field name. For more information on this syntax, refer to https://httpie.io/docs/cli/nested-json.
+{{request_items}}
 
 ## OPTIONS
 

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -1,4 +1,4 @@
-.TH XH 1 2026-01-14 0.25.3 "User Commands"
+.TH XH 1 2026-04-27 0.25.3 "User Commands"
 
 .SH NAME
 xh \- Friendly and fast tool for sending HTTP requests
@@ -89,41 +89,73 @@ Each --OPTION can be reset with a --no-OPTION argument.
 (default) Serialize data items from the command line as a JSON object.
 
 Overrides both \-\-form and \-\-multipart.
+
 .TP 4
 \fB\-f\fR, \fB\-\-form\fR
 Serialize data items from the command line as form fields.
 
 Overrides both \-\-json and \-\-multipart.
+
 .TP 4
 \fB\-\-multipart\fR
 Like \-\-form, but force a multipart/form\-data request even without files.
 
 Overrides both \-\-json and \-\-form.
+
 .TP 4
 \fB\-\-raw\fR=\fIRAW\fR
 Pass raw request data without extra processing.
+
 .TP 4
 \fB\-\-pretty\fR=\fISTYLE\fR
 Controls output processing. Possible values are:
 
-    all      (default) Enable both coloring and formatting
-    colors   Apply syntax highlighting to output
-    format   Pretty\-print json and sort headers
-    none     Disable both coloring and formatting
+.RS 8
+.TP 8
+all
+(default) Enable both coloring and formatting
+.TP 8
+colors
+Apply syntax highlighting to output
+.TP 8
+format
+Pretty\-print json and sort headers
+.TP 8
+none
+Disable both coloring and formatting
+.RE
+.RS 4
+.PP
 
 Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
+.RE
+
 .TP 4
 \fB\-\-format\-options\fR=\fIFORMAT_OPTIONS\fR
 Set output formatting options. Supported option are:
 
-    json.indent:<NUM>
-    json.format:<true|false>
-    headers.sort:<true|false>
+.RS 8
+.PP
+json.indent:<NUM>
+.PP
+json.format:<true|false>
+.PP
+xml.indent:<NUM>
+.PP
+xml.format:<true|false>
+.PP
+headers.sort:<true|false>
+.RE
+.RS 4
+.PP
 
 Example: \-\-format\-options=json.indent:2,headers.sort:false.
+.RE
+
 .TP 4
 \fB\-s\fR, \fB\-\-style\fR=\fITHEME\fR
 Output coloring style.
+
 
 [possible values: auto, solarized, monokai, fruity]
 .TP 4
@@ -131,31 +163,52 @@ Output coloring style.
 Override the response encoding for terminal display purposes.
 
 Example: \-\-response\-charset=latin1.
+
 .TP 4
 \fB\-\-response\-mime\fR=\fIMIME_TYPE\fR
 Override the response mime type for coloring and formatting for the terminal.
 
 Example: \-\-response\-mime=application/json.
+
 .TP 4
 \fB\-p\fR, \fB\-\-print\fR=\fIFORMAT\fR
 String specifying what the output should contain
 
-    'H' request headers
-    'B' request body
-    'h' response headers
-    'b' response body
-    'm' response metadata
+.RS 8
+.TP 8
+H
+request headers
+.TP 8
+B
+request body
+.TP 8
+h
+response headers
+.TP 8
+b
+response body
+.TP 8
+m
+response metadata
+.RE
+.RS 4
+.PP
 
 Example: \-\-print=Hb.
+.RE
+
 .TP 4
 \fB\-h\fR, \fB\-\-headers\fR
 Print only the response headers. Shortcut for \-\-print=h.
+
 .TP 4
 \fB\-b\fR, \fB\-\-body\fR
 Print only the response body. Shortcut for \-\-print=b.
+
 .TP 4
 \fB\-m\fR, \fB\-\-meta\fR
 Print only the response metadata. Shortcut for \-\-print=m.
+
 .TP 4
 \fB\-v\fR, \fB\-\-verbose\fR
 Print the whole request as well as the response.
@@ -165,25 +218,31 @@ Additionally, this enables \-\-all for printing intermediary requests/responses 
 Using verbose twice i.e. \-vv will print the response metadata as well.
 
 Equivalent to \-\-print=HhBb \-\-all.
+
 .TP 4
 \fB\-\-debug\fR
 Print full error stack traces and debug log messages.
 
 Logging can be configured in more detail using the `$RUST_LOG` environment variable. Set `RUST_LOG=trace` to show even more messages. See https://docs.rs/env_logger/0.11.3/env_logger/#enabling\-logging.
+
 .TP 4
 \fB\-\-all\fR
 Show any intermediary requests/responses while following redirects with \-\-follow.
+
 .TP 4
 \fB\-P\fR, \fB\-\-history\-print\fR=\fIFORMAT\fR
 The same as \-\-print but applies only to intermediary requests/responses.
+
 .TP 4
 \fB\-q\fR, \fB\-\-quiet\fR
 Do not print to stdout or stderr.
 
 Using quiet twice i.e. \-qq will suppress warnings as well.
+
 .TP 4
 \fB\-S\fR, \fB\-\-stream\fR
 Always stream the response body.
+
 .TP 4
 \fB\-x\fR, \fB\-\-compress\fR
 Content compressed (encoded) with Deflate algorithm.
@@ -193,28 +252,35 @@ The Content\-Encoding header is set to deflate.
 Compression is skipped if it appears that compression ratio is negative. Compression can be forced by repeating this option.
 
 Note: Compression cannot be used if the Content\-Encoding request header is present.
+
 .TP 4
 \fB\-o\fR, \fB\-\-output\fR=\fIFILE\fR
 Save output to FILE instead of stdout.
+
 .TP 4
 \fB\-d\fR, \fB\-\-download\fR
 Download the body to a file instead of printing it.
 
 The Accept\-Encoding header is set to identity and any redirects will be followed.
+
 .TP 4
 \fB\-c\fR, \fB\-\-continue\fR
 Resume an interrupted download. Requires \-\-download and \-\-output.
+
 .TP 4
 \fB\-\-session\fR=\fIFILE\fR
 Create, or reuse and update a session.
 
 Within a session, custom headers, auth credentials, as well as any cookies sent by the server persist between requests.
+
 .TP 4
 \fB\-\-session\-read\-only\fR=\fIFILE\fR
 Create or read a session without updating it from the request/response exchange.
+
 .TP 4
 \fB\-A\fR, \fB\-\-auth\-type\fR=\fIAUTH_TYPE\fR
 Specify the auth mechanism.
+
 
 [possible values: basic, bearer, digest]
 .TP 4
@@ -224,12 +290,15 @@ Authenticate as USER with PASS (\-A basic|digest) or with TOKEN (\-A bearer).
 PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
 
 TOKEN is expected if \-\-auth\-type=bearer.
+
 .TP 4
 \fB\-\-ignore\-netrc\fR
 Do not use credentials from .netrc.
+
 .TP 4
 \fB\-\-offline\fR
 Construct HTTP requests without sending them anywhere.
+
 .TP 4
 \fB\-\-check\-status\fR
 (default) Exit with an error status code if the server replies with an error.
@@ -237,17 +306,21 @@ Construct HTTP requests without sending them anywhere.
 The exit code will be 4 on 4xx (Client Error), 5 on 5xx (Server Error), or 3 on 3xx (Redirect) if \-\-follow isn't set.
 
 If stdout is redirected then a warning is written to stderr.
+
 .TP 4
 \fB\-F\fR, \fB\-\-follow\fR
 Do follow redirects.
+
 .TP 4
 \fB\-\-max\-redirects\fR=\fINUM\fR
 Number of redirects to follow. Only respected if \-\-follow is used.
+
 .TP 4
 \fB\-\-timeout\fR=\fISEC\fR
 Connection timeout of the request.
 
 The default value is "0", i.e., there is no timeout limit.
+
 .TP 4
 \fB\-\-proxy\fR=\fIPROTOCOL:URL\fR
 Use a proxy for a protocol. For example: \-\-proxy https:http://proxy.host:8080.
@@ -259,6 +332,7 @@ If your proxy requires credentials, put them in the URL, like so: \-\-proxy http
 You can specify proxies for multiple protocols by repeating this option.
 
 The environment variables "ALL_PROXY", "HTTP_PROXY" and "HTTPS_PROXY" can also be used, but are completely ignored if \-\-proxy is passed.
+
 .TP 4
 \fB\-\-verify\fR=\fIVERIFY\fR
 If "no", skip SSL verification. If a file path, use it as a CA bundle.
@@ -266,30 +340,37 @@ If "no", skip SSL verification. If a file path, use it as a CA bundle.
 Specifying a CA bundle will disable the system's built\-in root certificates.
 
 "false" instead of "no" also works. The default is "yes" ("true").
+
 .TP 4
 \fB\-\-cert\fR=\fIFILE\fR
 Use a client side certificate for SSL.
+
 .TP 4
 \fB\-\-cert\-key\fR=\fIFILE\fR
 A private key file to use with \-\-cert.
 
 Only necessary if the private key is not contained in the cert file.
+
 .TP 4
 \fB\-\-ssl\fR=\fIVERSION\fR
 Force a particular TLS version.
 
 "auto" gives the default behavior of negotiating a version with the server.
 
+
 [possible values: auto, tls1, tls1.1, tls1.2, tls1.3]
 .TP 4
 \fB\-\-native\-tls\fR
 Use the system TLS library instead of rustls (if enabled at compile time).
+
 .TP 4
 \fB\-\-https\fR
 Make HTTPS requests if not specified in the URL.
+
 .TP 4
 \fB\-\-http\-version\fR=\fIVERSION\fR
 HTTP version to use.
+
 
 [possible values: 1.0, 1.1, 2, 2\-prior\-knowledge, 3\-prior\-knowledge]
 .TP 4
@@ -299,22 +380,27 @@ Override DNS resolution for specific domain to a custom IP.
 You can override multiple domains by repeating this option.
 
 Example: \-\-resolve=example.com:127.0.0.1.
+
 .TP 4
 \fB\-\-interface\fR=\fINAME\fR
 Bind to a network interface or local IP address.
 
 Example: \-\-interface=eth0 \-\-interface=192.168.0.2.
+
 .TP 4
 \fB\-4\fR, \fB\-\-ipv4\fR
 Resolve hostname to ipv4 addresses only.
+
 .TP 4
 \fB\-6\fR, \fB\-\-ipv6\fR
 Resolve hostname to ipv6 addresses only.
+
 .TP 4
 \fB\-\-unix\-socket\fR=\fIFILE\fR
 Connect using a Unix domain socket.
 
 Example: xh :/index.html \-\-unix\-socket=/var/run/temp.sock.
+
 .TP 4
 \fB\-I\fR, \fB\-\-ignore\-stdin\fR
 Do not attempt to read stdin.
@@ -322,30 +408,54 @@ Do not attempt to read stdin.
 This disables the default behaviour of reading the request body from stdin when a redirected input is detected.
 
 It is recommended to pass this flag when using xh for scripting purposes. For more information, refer to https://httpie.io/docs/cli/best\-practices.
+
 .TP 4
 \fB\-\-curl\fR
 Print a translation to a curl command.
 
 For translating the other way, try https://curl2httpie.online/.
+
 .TP 4
 \fB\-\-curl\-long\fR
 Use the long versions of curl's flags.
+
 .TP 4
 \fB\-\-generate\fR=\fIKIND\fR
 Generate shell completions or man pages. Possible values are:
 
-    complete\-bash         Generate completions for bash
-    complete\-elvish       Generate completions for elvish
-    complete\-fish         Generage completions for fish
-    complete\-nushell      Generate completions for nushell
-    complete\-powershell   Generate completions for powershell
-    complete\-zsh          Generate completions for zsh
-    man                   Generate manual page in roff format
+.RS 8
+.TP 8
+complete\-bash
+Generate completions for bash
+.TP 8
+complete\-elvish
+Generate completions for elvish
+.TP 8
+complete\-fish
+Generage completions for fish
+.TP 8
+complete\-nushell
+Generate completions for nushell
+.TP 8
+complete\-powershell
+Generate completions for powershell
+.TP 8
+complete\-zsh
+Generate completions for zsh
+.TP 8
+man
+Generate manual page in roff format
+.RE
+.RS 4
+.PP
 
 Example: xh \-\-generate=complete\-bash > xh.bash.
+.RE
+
 .TP 4
 \fB\-\-help\fR
 Print help.
+
 .TP 4
 \fB\-V\fR, \fB\-\-version\fR
 Print version.

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -1,4 +1,4 @@
-.TH XH 1 2026-04-27 0.25.3 "User Commands"
+.TH XH 1 2026-05-01 0.25.3 "User Commands"
 
 .SH NAME
 xh \- Friendly and fast tool for sending HTTP requests
@@ -41,18 +41,22 @@ to "localhost:8000", and ":/path" is equivalent to "localhost/path".
 Optional key\-value pairs to be included in the request.
 
 The separator is used to determine the type:
+
 .RS 8
 .TP 4
 key==value
 Add a query string to the URL.
+
 .TP 4
 key=value
 Add a JSON property (\-\-json) or form field (\-\-form) to the request body.
+
 .TP 4
 key:=value
 Add a field with a literal JSON value to the request body.
 
 Example: "numbers:=[1,2,3] enabled:=true"
+
 .TP 4
 key@filename
 Upload a file (requires \-\-form or \-\-multipart).
@@ -60,27 +64,30 @@ Upload a file (requires \-\-form or \-\-multipart).
 To set the filename and mimetype, ";type=" and ";filename=" can be used respectively.
 
 Example: "pfp@ra.jpg;type=image/jpeg;filename=profile.jpg"
+
 .TP 4
 @filename
 Use a file as the request body.
+
 .TP 4
 header:value
 Add a header, e.g. "user\-agent:foobar"
+
 .TP 4
 header:
 Unset a header, e.g. "connection:"
+
 .TP 4
 header;
 Add a header with an empty value.
-.RE
 
-.RS
+.RE
+.IP
 An "@" prefix can be used to read a value from a file. For example: "x\-api\-key:@api\-key.txt".
 
 A backslash can be used to escape special characters, e.g. "weird\\:key=value".
 
 To construct a complex JSON object, the REQUEST_ITEM's key can be set to a JSON path instead of a field name. For more information on this syntax, refer to https://httpie.io/docs/cli/nested\-json.
-.RE
 
 .SH OPTIONS
 Each --OPTION can be reset with a --no-OPTION argument.
@@ -123,34 +130,30 @@ Pretty\-print json and sort headers
 .TP 8
 none
 Disable both coloring and formatting
-.RE
-.RS 4
-.PP
 
-Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
 .RE
+.IP
+Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
 
 .TP 4
 \fB\-\-format\-options\fR=\fIFORMAT_OPTIONS\fR
 Set output formatting options. Supported option are:
 
 .RS 8
-.PP
+.IP "" 0
 json.indent:<NUM>
-.PP
+.IP "" 0
 json.format:<true|false>
-.PP
+.IP "" 0
 xml.indent:<NUM>
-.PP
+.IP "" 0
 xml.format:<true|false>
-.PP
+.IP "" 0
 headers.sort:<true|false>
-.RE
-.RS 4
-.PP
 
-Example: \-\-format\-options=json.indent:2,headers.sort:false.
 .RE
+.IP
+Example: \-\-format\-options=json.indent:2,headers.sort:false.
 
 .TP 4
 \fB\-s\fR, \fB\-\-style\fR=\fITHEME\fR
@@ -190,12 +193,10 @@ response body
 .TP 8
 m
 response metadata
-.RE
-.RS 4
-.PP
 
-Example: \-\-print=Hb.
 .RE
+.IP
+Example: \-\-print=Hb.
 
 .TP 4
 \fB\-h\fR, \fB\-\-headers\fR
@@ -445,12 +446,10 @@ Generate completions for zsh
 .TP 8
 man
 Generate manual page in roff format
-.RE
-.RS 4
-.PP
 
-Example: xh \-\-generate=complete\-bash > xh.bash.
 .RE
+.IP
+Example: xh \-\-generate=complete\-bash > xh.bash.
 
 .TP 4
 \fB\-\-help\fR

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -446,6 +446,9 @@ Generate completions for zsh
 .TP 8
 man
 Generate manual page in roff format
+.TP 8
+markdown
+Generate manual page in markdown format
 
 .RE
 .IP

--- a/doc/xh.1
+++ b/doc/xh.1
@@ -1,4 +1,4 @@
-.TH XH 1 2026-05-01 0.25.3 "User Commands"
+.TH XH 1 2026-05-08 0.25.3 "User Commands"
 
 .SH NAME
 xh \- Friendly and fast tool for sending HTTP requests
@@ -447,7 +447,7 @@ Generate completions for zsh
 man
 Generate manual page in roff format
 .TP 8
-markdown
+man\-markdown
 Generate manual page in markdown format
 
 .RE

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -115,7 +115,8 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-s`, `--style`=`THEME`: Output coloring style.
 
-  [possible values: auto, solarized, monokai, fruity]
+  [possible values: `auto`, `solarized`, `monokai`, `fruity`]
+
 - `--response-charset`=`ENCODING`: Override the response encoding for terminal display purposes.
   
   Example: --response-charset=latin1.
@@ -186,7 +187,8 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-A`, `--auth-type`=`AUTH_TYPE`: Specify the auth mechanism.
 
-  [possible values: basic, bearer, digest]
+  [possible values: `basic`, `bearer`, `digest`]
+
 - `-a`, `--auth`=`USER[:PASS] | TOKEN`: Authenticate as USER with PASS (-A basic|digest) or with TOKEN (-A bearer).
   
   PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
@@ -237,14 +239,16 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   
   "auto" gives the default behavior of negotiating a version with the server.
 
-  [possible values: auto, tls1, tls1.1, tls1.2, tls1.3]
+  [possible values: `auto`, `tls1`, `tls1.1`, `tls1.2`, `tls1.3`]
+
 - `--native-tls`: Use the system TLS library instead of rustls (if enabled at compile time).
 
 - `--https`: Make HTTPS requests if not specified in the URL.
 
 - `--http-version`=`VERSION`: HTTP version to use.
 
-  [possible values: 1.0, 1.1, 2, 2-prior-knowledge, 3-prior-knowledge]
+  [possible values: `1.0`, `1.1`, `2`, `2-prior-knowledge`, `3-prior-knowledge`]
+
 - `--resolve`=`HOST:ADDRESS`: Override DNS resolution for specific domain to a custom IP.
   
   You can override multiple domains by repeating this option.

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -81,59 +81,58 @@ command instead of sending a request.
 Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-j`, `--json`: (default) Serialize data items from the command line as a JSON object.
-    
-    Overrides both --form and --multipart.
+  
+  Overrides both --form and --multipart.
 
 - `-f`, `--form`: Serialize data items from the command line as form fields.
-    
-    Overrides both --json and --multipart.
+  
+  Overrides both --json and --multipart.
 
 - `--multipart`: Like --form, but force a multipart/form-data request even without files.
-    
-    Overrides both --json and --form.
+  
+  Overrides both --json and --form.
 
 - `--raw`=`RAW`: Pass raw request data without extra processing.
 
 - `--pretty`=`STYLE`: Controls output processing. Possible values are:
-    
-    - all      (default) Enable both coloring and formatting
-    - colors   Apply syntax highlighting to output
-    - format   Pretty-print json and sort headers
-    - none     Disable both coloring and formatting
-    
-    Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
+  
+  - `all`: (default) Enable both coloring and formatting
+  - `colors`: Apply syntax highlighting to output
+  - `format`: Pretty-print json and sort headers
+  - `none`: Disable both coloring and formatting
+  
+  Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
 
 - `--format-options`=`FORMAT_OPTIONS`: Set output formatting options. Supported option are:
-    
-    - json.indent:<NUM>
-    - json.format:<true|false>
-    - xml.indent:<NUM>
-    - xml.format:<true|false>
-    - headers.sort:<true|false>
-    
-    Example: --format-options=json.indent:2,xml.indent:2,headers.sort:false.
+  
+  - `json.indent:<NUM>`
+  - `json.format:<true|false>`
+  - `xml.indent:<NUM>`
+  - `xml.format:<true|false>`
+  - `headers.sort:<true|false>`
+  
+  Example: --format-options=json.indent:2,headers.sort:false.
 
 - `-s`, `--style`=`THEME`: Output coloring style.
 
-    [possible values: auto, solarized, monokai, fruity]
-
+  [possible values: auto, solarized, monokai, fruity]
 - `--response-charset`=`ENCODING`: Override the response encoding for terminal display purposes.
-    
-    Example: --response-charset=latin1.
+  
+  Example: --response-charset=latin1.
 
 - `--response-mime`=`MIME_TYPE`: Override the response mime type for coloring and formatting for the terminal.
-    
-    Example: --response-mime=application/json.
+  
+  Example: --response-mime=application/json.
 
 - `-p`, `--print`=`FORMAT`: String specifying what the output should contain
-    
-    - 'H' request headers
-    - 'B' request body
-    - 'h' response headers
-    - 'b' response body
-    - 'm' response metadata
-    
-    Example: --print=Hb.
+  
+  - `H`: request headers
+  - `B`: request body
+  - `h`: response headers
+  - `b`: response body
+  - `m`: response metadata
+  
+  Example: --print=Hb.
 
 - `-h`, `--headers`: Print only the response headers. Shortcut for --print=h.
 
@@ -142,154 +141,151 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 - `-m`, `--meta`: Print only the response metadata. Shortcut for --print=m.
 
 - `-v`, `--verbose`: Print the whole request as well as the response.
-    
-    Additionally, this enables --all for printing intermediary requests/responses while following redirects.
-    
-    Using verbose twice i.e. -vv will print the response metadata as well.
-    
-    Equivalent to --print=HhBb --all.
+  
+  Additionally, this enables --all for printing intermediary requests/responses while following redirects.
+  
+  Using verbose twice i.e. -vv will print the response metadata as well.
+  
+  Equivalent to --print=HhBb --all.
 
 - `--debug`: Print full error stack traces and debug log messages.
-    
-    Logging can be configured in more detail using the `$RUST_LOG` environment variable. Set `RUST_LOG=trace` to show even more messages. See https://docs.rs/env_logger/0.11.3/env_logger/#enabling-logging.
+  
+  Logging can be configured in more detail using the `$RUST_LOG` environment variable. Set `RUST_LOG=trace` to show even more messages. See https://docs.rs/env_logger/0.11.3/env_logger/#enabling-logging.
 
 - `--all`: Show any intermediary requests/responses while following redirects with --follow.
 
 - `-P`, `--history-print`=`FORMAT`: The same as --print but applies only to intermediary requests/responses.
 
 - `-q`, `--quiet`: Do not print to stdout or stderr.
-    
-    Using quiet twice i.e. -qq will suppress warnings as well.
+  
+  Using quiet twice i.e. -qq will suppress warnings as well.
 
 - `-S`, `--stream`: Always stream the response body.
 
 - `-x`, `--compress`: Content compressed (encoded) with Deflate algorithm.
-    
-    The Content-Encoding header is set to deflate.
-    
-    Compression is skipped if it appears that compression ratio is negative. Compression can be forced by repeating this option.
-    
-    Note: Compression cannot be used if the Content-Encoding request header is present.
+  
+  The Content-Encoding header is set to deflate.
+  
+  Compression is skipped if it appears that compression ratio is negative. Compression can be forced by repeating this option.
+  
+  Note: Compression cannot be used if the Content-Encoding request header is present.
 
 - `-o`, `--output`=`FILE`: Save output to FILE instead of stdout.
 
 - `-d`, `--download`: Download the body to a file instead of printing it.
-    
-    The Accept-Encoding header is set to identity and any redirects will be followed.
+  
+  The Accept-Encoding header is set to identity and any redirects will be followed.
 
 - `-c`, `--continue`: Resume an interrupted download. Requires --download and --output.
 
 - `--session`=`FILE`: Create, or reuse and update a session.
-    
-    Within a session, custom headers, auth credentials, as well as any cookies sent by the server persist between requests.
+  
+  Within a session, custom headers, auth credentials, as well as any cookies sent by the server persist between requests.
 
 - `--session-read-only`=`FILE`: Create or read a session without updating it from the request/response exchange.
 
 - `-A`, `--auth-type`=`AUTH_TYPE`: Specify the auth mechanism.
 
-    [possible values: basic, bearer, digest]
-
+  [possible values: basic, bearer, digest]
 - `-a`, `--auth`=`USER[:PASS] | TOKEN`: Authenticate as USER with PASS (-A basic|digest) or with TOKEN (-A bearer).
-    
-    PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
-    
-    TOKEN is expected if --auth-type=bearer.
+  
+  PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
+  
+  TOKEN is expected if --auth-type=bearer.
 
 - `--ignore-netrc`: Do not use credentials from .netrc.
 
 - `--offline`: Construct HTTP requests without sending them anywhere.
 
 - `--check-status`: (default) Exit with an error status code if the server replies with an error.
-    
-    The exit code will be 4 on 4xx (Client Error), 5 on 5xx (Server Error), or 3 on 3xx (Redirect) if --follow isn't set.
-    
-    If stdout is redirected then a warning is written to stderr.
+  
+  The exit code will be 4 on 4xx (Client Error), 5 on 5xx (Server Error), or 3 on 3xx (Redirect) if --follow isn't set.
+  
+  If stdout is redirected then a warning is written to stderr.
 
 - `-F`, `--follow`: Do follow redirects.
 
 - `--max-redirects`=`NUM`: Number of redirects to follow. Only respected if --follow is used.
 
 - `--timeout`=`SEC`: Connection timeout of the request.
-    
-    The default value is "0", i.e., there is no timeout limit.
+  
+  The default value is "0", i.e., there is no timeout limit.
 
 - `--proxy`=`PROTOCOL:URL`: Use a proxy for a protocol. For example: --proxy https:http://proxy.host:8080.
-    
-    PROTOCOL can be "all", "http" or "https".
-    
-    If your proxy requires credentials, put them in the URL, like so: --proxy http:socks5://user:password@proxy.host:8000.
-    
-    You can specify proxies for multiple protocols by repeating this option.
-    
-    The environment variables "ALL_PROXY", "HTTP_PROXY" and "HTTPS_PROXY" can also be used, but are completely ignored if --proxy is passed.
+  
+  PROTOCOL can be "all", "http" or "https".
+  
+  If your proxy requires credentials, put them in the URL, like so: --proxy http:socks5://user:password@proxy.host:8000.
+  
+  You can specify proxies for multiple protocols by repeating this option.
+  
+  The environment variables "ALL_PROXY", "HTTP_PROXY" and "HTTPS_PROXY" can also be used, but are completely ignored if --proxy is passed.
 
 - `--verify`=`VERIFY`: If "no", skip SSL verification. If a file path, use it as a CA bundle.
-    
-    Specifying a CA bundle will disable the system's built-in root certificates.
-    
-    "false" instead of "no" also works. The default is "yes" ("true").
+  
+  Specifying a CA bundle will disable the system's built-in root certificates.
+  
+  "false" instead of "no" also works. The default is "yes" ("true").
 
 - `--cert`=`FILE`: Use a client side certificate for SSL.
 
 - `--cert-key`=`FILE`: A private key file to use with --cert.
-    
-    Only necessary if the private key is not contained in the cert file.
+  
+  Only necessary if the private key is not contained in the cert file.
 
 - `--ssl`=`VERSION`: Force a particular TLS version.
-    
-    "auto" gives the default behavior of negotiating a version with the server.
+  
+  "auto" gives the default behavior of negotiating a version with the server.
 
-    [possible values: auto, tls1, tls1.1, tls1.2, tls1.3]
-
+  [possible values: auto, tls1, tls1.1, tls1.2, tls1.3]
 - `--native-tls`: Use the system TLS library instead of rustls (if enabled at compile time).
 
 - `--https`: Make HTTPS requests if not specified in the URL.
 
 - `--http-version`=`VERSION`: HTTP version to use.
 
-    [possible values: 1.0, 1.1, 2, 2-prior-knowledge, 3-prior-knowledge]
-
+  [possible values: 1.0, 1.1, 2, 2-prior-knowledge, 3-prior-knowledge]
 - `--resolve`=`HOST:ADDRESS`: Override DNS resolution for specific domain to a custom IP.
-    
-    You can override multiple domains by repeating this option.
-    
-    Example: --resolve=example.com:127.0.0.1.
+  
+  You can override multiple domains by repeating this option.
+  
+  Example: --resolve=example.com:127.0.0.1.
 
 - `--interface`=`NAME`: Bind to a network interface or local IP address.
-    
-    Example: --interface=eth0 --interface=192.168.0.2.
+  
+  Example: --interface=eth0 --interface=192.168.0.2.
 
 - `-4`, `--ipv4`: Resolve hostname to ipv4 addresses only.
 
 - `-6`, `--ipv6`: Resolve hostname to ipv6 addresses only.
 
 - `--unix-socket`=`FILE`: Connect using a Unix domain socket.
-    
-    Example: xh :/index.html --unix-socket=/var/run/temp.sock.
+  
+  Example: xh :/index.html --unix-socket=/var/run/temp.sock.
 
 - `-I`, `--ignore-stdin`: Do not attempt to read stdin.
-    
-    This disables the default behaviour of reading the request body from stdin when a redirected input is detected.
-    
-    It is recommended to pass this flag when using xh for scripting purposes. For more information, refer to https://httpie.io/docs/cli/best-practices.
+  
+  This disables the default behaviour of reading the request body from stdin when a redirected input is detected.
+  
+  It is recommended to pass this flag when using xh for scripting purposes. For more information, refer to https://httpie.io/docs/cli/best-practices.
 
 - `--curl`: Print a translation to a curl command.
-    
-    For translating the other way, try https://curl2httpie.online/.
+  
+  For translating the other way, try https://curl2httpie.online/.
 
 - `--curl-long`: Use the long versions of curl's flags.
 
 - `--generate`=`KIND`: Generate shell completions or man pages. Possible values are:
-    
-    - complete-bash         Generate completions for bash
-    - complete-elvish       Generate completions for elvish
-    - complete-fish         Generage completions for fish
-    - complete-nushell      Generate completions for nushell
-    - complete-powershell   Generate completions for powershell
-    - complete-zsh          Generate completions for zsh
-    - man                   Generate manual page in roff format
-    
-    Example: xh --generate=complete-bash > xh.bash.
+  
+  - `complete-bash`: Generate completions for bash
+  - `complete-elvish`: Generate completions for elvish
+  - `complete-fish`: Generage completions for fish
+  - `complete-nushell`: Generate completions for nushell
+  - `complete-powershell`: Generate completions for powershell
+  - `complete-zsh`: Generate completions for zsh
+  - `man`: Generate manual page in roff format
+  
+  Example: xh --generate=complete-bash > xh.bash.
 
 - `--help`: Print help.
 

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -1,0 +1,413 @@
+## NAME
+
+`xh` - Friendly and fast tool for sending HTTP requests
+
+## SYNOPSIS
+
+```
+xh [OPTIONS] [METHOD] URL [REQUEST_ITEM ...]
+```
+
+## DESCRIPTION
+
+**xh** is an HTTP client with a friendly command line interface. It strives to
+have readable output and easy-to-use options.
+
+xh is mostly compatible with HTTPie: see http(1).
+
+The `--curl` option can be used to print a curl(1) translation of the
+command instead of sending a request.
+
+## POSITIONAL ARGUMENTS
+
+- `[METHOD]`:
+  The HTTP method to use for the request.
+  
+  This defaults to GET, or to POST if the request contains a body.
+
+- `URL`:
+  The URL to request.
+
+  The URL scheme defaults to `http://` normally, or `https://` if
+  the program is invoked as `xhs`.
+
+  A leading colon works as shorthand for localhost. `:8000` is equivalent
+  to `localhost:8000`, and `:/path` is equivalent to `localhost/path`.
+
+- `[REQUEST_ITEM ...]`:
+
+  Optional key-value pairs to be included in the request.
+
+  The separator is used to determine the type:
+
+  - `key==value`:
+    Add a query string to the URL.
+
+  - `key=value`:
+    Add a JSON property (`--json`) or form field (`--form`) to the request body.
+
+  - `key:=value`:
+    Add a field with a literal JSON value to the request body.
+  
+    Example: `numbers:=[1,2,3] enabled:=true`
+
+  - `key@filename`:
+    Upload a file (requires `--form` or `--multipart`).
+  
+    To set the filename and mimetype, `;type=` and `;filename=` can be used respectively.
+  
+    Example: `pfp@ra.jpg;type=image/jpeg;filename=profile.jpg`
+
+  - `@filename`:
+    Use a file as the request body.
+
+  - `header:value`:
+    Add a header, e.g. `user-agent:foobar`
+
+  - `header:`:
+    Unset a header, e.g. `connection:`
+
+  - `header;`:
+    Add a header with an empty value.
+
+  An `@` prefix can be used to read a value from a file. For example: `x-api-key:@api-key.txt`.
+  
+  A backslash can be used to escape special characters, e.g. `weird\:key=value`.
+  
+  To construct a complex JSON object, the `REQUEST_ITEM`'s key can be set to a JSON path instead of a field name. For more information on this syntax, refer to https://httpie.io/docs/cli/nested-json.
+
+## OPTIONS
+
+Each `--OPTION` can be reset with a `--no-OPTION` argument.
+
+- `-j`, `--json`: (default) Serialize data items from the command line as a JSON object.
+    
+    Overrides both --form and --multipart.
+
+- `-f`, `--form`: Serialize data items from the command line as form fields.
+    
+    Overrides both --json and --multipart.
+
+- `--multipart`: Like --form, but force a multipart/form-data request even without files.
+    
+    Overrides both --json and --form.
+
+- `--raw`=`RAW`: Pass raw request data without extra processing.
+
+- `--pretty`=`STYLE`: Controls output processing. Possible values are:
+    
+    - all      (default) Enable both coloring and formatting
+    - colors   Apply syntax highlighting to output
+    - format   Pretty-print json and sort headers
+    - none     Disable both coloring and formatting
+    
+    Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
+
+- `--format-options`=`FORMAT_OPTIONS`: Set output formatting options. Supported option are:
+    
+    - json.indent:<NUM>
+    - json.format:<true|false>
+    - xml.indent:<NUM>
+    - xml.format:<true|false>
+    - headers.sort:<true|false>
+    
+    Example: --format-options=json.indent:2,xml.indent:2,headers.sort:false.
+
+- `-s`, `--style`=`THEME`: Output coloring style.
+
+    [possible values: auto, solarized, monokai, fruity]
+
+- `--response-charset`=`ENCODING`: Override the response encoding for terminal display purposes.
+    
+    Example: --response-charset=latin1.
+
+- `--response-mime`=`MIME_TYPE`: Override the response mime type for coloring and formatting for the terminal.
+    
+    Example: --response-mime=application/json.
+
+- `-p`, `--print`=`FORMAT`: String specifying what the output should contain
+    
+    - 'H' request headers
+    - 'B' request body
+    - 'h' response headers
+    - 'b' response body
+    - 'm' response metadata
+    
+    Example: --print=Hb.
+
+- `-h`, `--headers`: Print only the response headers. Shortcut for --print=h.
+
+- `-b`, `--body`: Print only the response body. Shortcut for --print=b.
+
+- `-m`, `--meta`: Print only the response metadata. Shortcut for --print=m.
+
+- `-v`, `--verbose`: Print the whole request as well as the response.
+    
+    Additionally, this enables --all for printing intermediary requests/responses while following redirects.
+    
+    Using verbose twice i.e. -vv will print the response metadata as well.
+    
+    Equivalent to --print=HhBb --all.
+
+- `--debug`: Print full error stack traces and debug log messages.
+    
+    Logging can be configured in more detail using the `$RUST_LOG` environment variable. Set `RUST_LOG=trace` to show even more messages. See https://docs.rs/env_logger/0.11.3/env_logger/#enabling-logging.
+
+- `--all`: Show any intermediary requests/responses while following redirects with --follow.
+
+- `-P`, `--history-print`=`FORMAT`: The same as --print but applies only to intermediary requests/responses.
+
+- `-q`, `--quiet`: Do not print to stdout or stderr.
+    
+    Using quiet twice i.e. -qq will suppress warnings as well.
+
+- `-S`, `--stream`: Always stream the response body.
+
+- `-x`, `--compress`: Content compressed (encoded) with Deflate algorithm.
+    
+    The Content-Encoding header is set to deflate.
+    
+    Compression is skipped if it appears that compression ratio is negative. Compression can be forced by repeating this option.
+    
+    Note: Compression cannot be used if the Content-Encoding request header is present.
+
+- `-o`, `--output`=`FILE`: Save output to FILE instead of stdout.
+
+- `-d`, `--download`: Download the body to a file instead of printing it.
+    
+    The Accept-Encoding header is set to identity and any redirects will be followed.
+
+- `-c`, `--continue`: Resume an interrupted download. Requires --download and --output.
+
+- `--session`=`FILE`: Create, or reuse and update a session.
+    
+    Within a session, custom headers, auth credentials, as well as any cookies sent by the server persist between requests.
+
+- `--session-read-only`=`FILE`: Create or read a session without updating it from the request/response exchange.
+
+- `-A`, `--auth-type`=`AUTH_TYPE`: Specify the auth mechanism.
+
+    [possible values: basic, bearer, digest]
+
+- `-a`, `--auth`=`USER[:PASS] | TOKEN`: Authenticate as USER with PASS (-A basic|digest) or with TOKEN (-A bearer).
+    
+    PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
+    
+    TOKEN is expected if --auth-type=bearer.
+
+- `--ignore-netrc`: Do not use credentials from .netrc.
+
+- `--offline`: Construct HTTP requests without sending them anywhere.
+
+- `--check-status`: (default) Exit with an error status code if the server replies with an error.
+    
+    The exit code will be 4 on 4xx (Client Error), 5 on 5xx (Server Error), or 3 on 3xx (Redirect) if --follow isn't set.
+    
+    If stdout is redirected then a warning is written to stderr.
+
+- `-F`, `--follow`: Do follow redirects.
+
+- `--max-redirects`=`NUM`: Number of redirects to follow. Only respected if --follow is used.
+
+- `--timeout`=`SEC`: Connection timeout of the request.
+    
+    The default value is "0", i.e., there is no timeout limit.
+
+- `--proxy`=`PROTOCOL:URL`: Use a proxy for a protocol. For example: --proxy https:http://proxy.host:8080.
+    
+    PROTOCOL can be "all", "http" or "https".
+    
+    If your proxy requires credentials, put them in the URL, like so: --proxy http:socks5://user:password@proxy.host:8000.
+    
+    You can specify proxies for multiple protocols by repeating this option.
+    
+    The environment variables "ALL_PROXY", "HTTP_PROXY" and "HTTPS_PROXY" can also be used, but are completely ignored if --proxy is passed.
+
+- `--verify`=`VERIFY`: If "no", skip SSL verification. If a file path, use it as a CA bundle.
+    
+    Specifying a CA bundle will disable the system's built-in root certificates.
+    
+    "false" instead of "no" also works. The default is "yes" ("true").
+
+- `--cert`=`FILE`: Use a client side certificate for SSL.
+
+- `--cert-key`=`FILE`: A private key file to use with --cert.
+    
+    Only necessary if the private key is not contained in the cert file.
+
+- `--ssl`=`VERSION`: Force a particular TLS version.
+    
+    "auto" gives the default behavior of negotiating a version with the server.
+
+    [possible values: auto, tls1, tls1.1, tls1.2, tls1.3]
+
+- `--native-tls`: Use the system TLS library instead of rustls (if enabled at compile time).
+
+- `--https`: Make HTTPS requests if not specified in the URL.
+
+- `--http-version`=`VERSION`: HTTP version to use.
+
+    [possible values: 1.0, 1.1, 2, 2-prior-knowledge, 3-prior-knowledge]
+
+- `--resolve`=`HOST:ADDRESS`: Override DNS resolution for specific domain to a custom IP.
+    
+    You can override multiple domains by repeating this option.
+    
+    Example: --resolve=example.com:127.0.0.1.
+
+- `--interface`=`NAME`: Bind to a network interface or local IP address.
+    
+    Example: --interface=eth0 --interface=192.168.0.2.
+
+- `-4`, `--ipv4`: Resolve hostname to ipv4 addresses only.
+
+- `-6`, `--ipv6`: Resolve hostname to ipv6 addresses only.
+
+- `--unix-socket`=`FILE`: Connect using a Unix domain socket.
+    
+    Example: xh :/index.html --unix-socket=/var/run/temp.sock.
+
+- `-I`, `--ignore-stdin`: Do not attempt to read stdin.
+    
+    This disables the default behaviour of reading the request body from stdin when a redirected input is detected.
+    
+    It is recommended to pass this flag when using xh for scripting purposes. For more information, refer to https://httpie.io/docs/cli/best-practices.
+
+- `--curl`: Print a translation to a curl command.
+    
+    For translating the other way, try https://curl2httpie.online/.
+
+- `--curl-long`: Use the long versions of curl's flags.
+
+- `--generate`=`KIND`: Generate shell completions or man pages. Possible values are:
+    
+    - complete-bash         Generate completions for bash
+    - complete-elvish       Generate completions for elvish
+    - complete-fish         Generage completions for fish
+    - complete-nushell      Generate completions for nushell
+    - complete-powershell   Generate completions for powershell
+    - complete-zsh          Generate completions for zsh
+    - man                   Generate manual page in roff format
+    
+    Example: xh --generate=complete-bash > xh.bash.
+
+- `--help`: Print help.
+
+- `-V`, `--version`: Print version.
+
+## EXIT STATUS
+
+- `0`: Successful program execution.
+- `1`: Usage, syntax or network error.
+- `2`: Request timeout.
+- `3`: Unexpected HTTP 3xx Redirection.
+- `4`: HTTP 4xx Client Error.
+- `5`: HTTP 5xx Server Error.
+- `6`: Too many redirects.
+
+## ENVIRONMENT
+
+- `XH_CONFIG_DIR`:
+  Specifies where to look for config.json and named session data.
+  The default is `~/.config/xh` for Linux/macOS and `%APPDATA%\xh` for Windows.
+
+- `XH_HTTPIE_COMPAT_MODE`:
+  Enables the HTTPie Compatibility Mode. The only current difference is that
+  `--check-status` is not enabled by default. An alternative to setting this
+  environment variable is to rename the binary to either http or https.
+
+- `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`:
+  Sets a custom CA bundle path.
+
+- `ALL_PROXY=[protocol://]<host>[:port]`:
+  Sets the proxy server for all requests (unless overridden for a specific protocol).
+
+- `HTTP_PROXY=[protocol://]<host>[:port]`:
+  Sets the proxy server to use for HTTP.
+
+- `HTTPS_PROXY=[protocol://]<host>[:port]`:
+  Sets the proxy server to use for HTTPS.
+
+- `NO_PROXY`:
+  List of comma-separated hosts for which to ignore the other proxy environment variables. `*` matches all host names.
+
+- `NETRC`:
+  Location of the `.netrc` file.
+
+- `NO_COLOR`:
+  Disables output coloring. See <https://no-color.org>
+
+- `RUST_LOG`:
+  Configure low-level debug messages. See https://docs.rs/env_logger/0.11.3/env_logger/#enabling-logging
+
+## FILES
+
+- `~/.config/xh/config.json`:
+  xh configuration file. The only configurable option is `default_options`
+  which is a list of default shell arguments that gets passed to `xh`.
+  Example:
+
+  ```json
+  { "default_options": ["--native-tls", "--style=solarized"] }
+  ```
+
+- `~/.netrc`, `~/_netrc`:
+Auto-login information file.
+
+- `~/.config/xh/sessions`:
+Session data directory grouped by domain and port number.
+
+## EXAMPLES
+
+Send a GET request:
+```
+xh httpbin.org/json
+```
+
+Send a POST request with body `{"name": "ahmed", "age": 24}`:
+```
+xh httpbin.org/post name=ahmed age:=24
+```
+
+Send a GET request to http://httpbin.org/json?id=5&sort=true:
+```
+xh get httpbin.org/json id==5 sort==true
+```
+
+Send a GET request and include a header named `X-Api-Key` with value `12345`:
+```
+xh get Ihttpbin.org/json x-api-key:12345
+```
+
+Send a POST request with body read from stdin:
+```
+echo "[1, 2, 3]" | xh post httpbin.org/post
+```
+
+Send a PUT request and pipe the result to `less`:
+```
+xh put httpbin.org/put id:=49 age:=25 | less
+```
+
+Download and save to `res.json`:
+```
+xh -d httpbin.org/json -o res.jso\fR
+```
+
+Make a request with a custom user agent:
+```
+xh httpbin.org/get user-agent:foobar
+```
+
+Make an HTTPS request to https://example.com:
+```
+xhs example.com
+```
+
+## REPORTING BUGS
+xh's Github issues https://github.com/ducaale/xh/issues
+
+## SEE ALSO
+curl(1), http(1)
+
+HTTPie's online documentation https://httpie.io/docs/cli

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -92,9 +92,9 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   
   Overrides both --json and --form.
 
-- `--raw`=`RAW`: Pass raw request data without extra processing.
+- `--raw=RAW`: Pass raw request data without extra processing.
 
-- `--pretty`=`STYLE`: Controls output processing. Possible values are:
+- `--pretty=STYLE`: Controls output processing. Possible values are:
   
   - `all`: (default) Enable both coloring and formatting
   - `colors`: Apply syntax highlighting to output
@@ -103,7 +103,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   
   Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
 
-- `--format-options`=`FORMAT_OPTIONS`: Set output formatting options. Supported option are:
+- `--format-options=FORMAT_OPTIONS`: Set output formatting options. Supported option are:
   
   - `json.indent:<NUM>`
   - `json.format:<true|false>`
@@ -113,19 +113,19 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   
   Example: --format-options=json.indent:2,headers.sort:false.
 
-- `-s`, `--style`=`THEME`: Output coloring style.
+- `-s`, `--style=THEME`: Output coloring style.
 
   [possible values: `auto`, `solarized`, `monokai`, `fruity`]
 
-- `--response-charset`=`ENCODING`: Override the response encoding for terminal display purposes.
+- `--response-charset=ENCODING`: Override the response encoding for terminal display purposes.
   
   Example: --response-charset=latin1.
 
-- `--response-mime`=`MIME_TYPE`: Override the response mime type for coloring and formatting for the terminal.
+- `--response-mime=MIME_TYPE`: Override the response mime type for coloring and formatting for the terminal.
   
   Example: --response-mime=application/json.
 
-- `-p`, `--print`=`FORMAT`: String specifying what the output should contain
+- `-p`, `--print=FORMAT`: String specifying what the output should contain
   
   - `H`: request headers
   - `B`: request body
@@ -155,7 +155,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `--all`: Show any intermediary requests/responses while following redirects with --follow.
 
-- `-P`, `--history-print`=`FORMAT`: The same as --print but applies only to intermediary requests/responses.
+- `-P`, `--history-print=FORMAT`: The same as --print but applies only to intermediary requests/responses.
 
 - `-q`, `--quiet`: Do not print to stdout or stderr.
   
@@ -171,7 +171,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   
   Note: Compression cannot be used if the Content-Encoding request header is present.
 
-- `-o`, `--output`=`FILE`: Save output to FILE instead of stdout.
+- `-o`, `--output=FILE`: Save output to FILE instead of stdout.
 
 - `-d`, `--download`: Download the body to a file instead of printing it.
   
@@ -179,17 +179,17 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-c`, `--continue`: Resume an interrupted download. Requires --download and --output.
 
-- `--session`=`FILE`: Create, or reuse and update a session.
+- `--session=FILE`: Create, or reuse and update a session.
   
   Within a session, custom headers, auth credentials, as well as any cookies sent by the server persist between requests.
 
-- `--session-read-only`=`FILE`: Create or read a session without updating it from the request/response exchange.
+- `--session-read-only=FILE`: Create or read a session without updating it from the request/response exchange.
 
-- `-A`, `--auth-type`=`AUTH_TYPE`: Specify the auth mechanism.
+- `-A`, `--auth-type=AUTH_TYPE`: Specify the auth mechanism.
 
   [possible values: `basic`, `bearer`, `digest`]
 
-- `-a`, `--auth`=`USER[:PASS] | TOKEN`: Authenticate as USER with PASS (-A basic|digest) or with TOKEN (-A bearer).
+- `-a`, `--auth=USER[:PASS] | TOKEN`: Authenticate as USER with PASS (-A basic|digest) or with TOKEN (-A bearer).
   
   PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
   
@@ -207,13 +207,13 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-F`, `--follow`: Do follow redirects.
 
-- `--max-redirects`=`NUM`: Number of redirects to follow. Only respected if --follow is used.
+- `--max-redirects=NUM`: Number of redirects to follow. Only respected if --follow is used.
 
-- `--timeout`=`SEC`: Connection timeout of the request.
+- `--timeout=SEC`: Connection timeout of the request.
   
   The default value is "0", i.e., there is no timeout limit.
 
-- `--proxy`=`PROTOCOL:URL`: Use a proxy for a protocol. For example: --proxy https:http://proxy.host:8080.
+- `--proxy=PROTOCOL:URL`: Use a proxy for a protocol. For example: --proxy https:http://proxy.host:8080.
   
   PROTOCOL can be "all", "http" or "https".
   
@@ -223,19 +223,19 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   
   The environment variables "ALL_PROXY", "HTTP_PROXY" and "HTTPS_PROXY" can also be used, but are completely ignored if --proxy is passed.
 
-- `--verify`=`VERIFY`: If "no", skip SSL verification. If a file path, use it as a CA bundle.
+- `--verify=VERIFY`: If "no", skip SSL verification. If a file path, use it as a CA bundle.
   
   Specifying a CA bundle will disable the system's built-in root certificates.
   
   "false" instead of "no" also works. The default is "yes" ("true").
 
-- `--cert`=`FILE`: Use a client side certificate for SSL.
+- `--cert=FILE`: Use a client side certificate for SSL.
 
-- `--cert-key`=`FILE`: A private key file to use with --cert.
+- `--cert-key=FILE`: A private key file to use with --cert.
   
   Only necessary if the private key is not contained in the cert file.
 
-- `--ssl`=`VERSION`: Force a particular TLS version.
+- `--ssl=VERSION`: Force a particular TLS version.
   
   "auto" gives the default behavior of negotiating a version with the server.
 
@@ -245,17 +245,17 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `--https`: Make HTTPS requests if not specified in the URL.
 
-- `--http-version`=`VERSION`: HTTP version to use.
+- `--http-version=VERSION`: HTTP version to use.
 
   [possible values: `1.0`, `1.1`, `2`, `2-prior-knowledge`, `3-prior-knowledge`]
 
-- `--resolve`=`HOST:ADDRESS`: Override DNS resolution for specific domain to a custom IP.
+- `--resolve=HOST:ADDRESS`: Override DNS resolution for specific domain to a custom IP.
   
   You can override multiple domains by repeating this option.
   
   Example: --resolve=example.com:127.0.0.1.
 
-- `--interface`=`NAME`: Bind to a network interface or local IP address.
+- `--interface=NAME`: Bind to a network interface or local IP address.
   
   Example: --interface=eth0 --interface=192.168.0.2.
 
@@ -263,7 +263,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-6`, `--ipv6`: Resolve hostname to ipv6 addresses only.
 
-- `--unix-socket`=`FILE`: Connect using a Unix domain socket.
+- `--unix-socket=FILE`: Connect using a Unix domain socket.
   
   Example: xh :/index.html --unix-socket=/var/run/temp.sock.
 
@@ -279,7 +279,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `--curl-long`: Use the long versions of curl's flags.
 
-- `--generate`=`KIND`: Generate shell completions or man pages. Possible values are:
+- `--generate=KIND`: Generate shell completions or man pages. Possible values are:
   
   - `complete-bash`: Generate completions for bash
   - `complete-elvish`: Generate completions for elvish

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -280,7 +280,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   - `complete-powershell`: Generate completions for powershell
   - `complete-zsh`: Generate completions for zsh
   - `man`: Generate manual page in roff format
-  - `markdown`: Generate manual page in markdown format
+  - `man-markdown`: Generate manual page in markdown format
     
   Example: xh --generate=complete-bash > xh.bash.
 

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -36,7 +36,7 @@ command instead of sending a request.
 
 - `[REQUEST_ITEM ...]`:
 
-Optional key-value pairs to be included in the request.
+  Optional key-value pairs to be included in the request.
   
   The separator is used to determine the type:
   

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -384,7 +384,7 @@ xh put httpbin.org/put id:=49 age:=25 | less
 
 Download and save to `res.json`:
 ```
-xh -d httpbin.org/json -o res.jso\fR
+xh -d httpbin.org/json -o res.json
 ```
 
 Make a request with a custom user agent:

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -36,45 +36,37 @@ command instead of sending a request.
 
 - `[REQUEST_ITEM ...]`:
 
-  Optional key-value pairs to be included in the request.
-
+Optional key-value pairs to be included in the request.
+  
   The separator is used to determine the type:
-
-  - `key==value`:
-    Add a query string to the URL.
-
-  - `key=value`:
-    Add a JSON property (`--json`) or form field (`--form`) to the request body.
-
-  - `key:=value`:
-    Add a field with a literal JSON value to the request body.
   
+  - `key==value`: Add a query string to the URL.
+    
+  - `key=value`: Add a JSON property (--json) or form field (--form) to the request body.
+    
+  - `key:=value`: Add a field with a literal JSON value to the request body.
+    
     Example: `numbers:=[1,2,3] enabled:=true`
-
-  - `key@filename`:
-    Upload a file (requires `--form` or `--multipart`).
-  
+    
+  - `key@filename`: Upload a file (requires --form or --multipart).
+    
     To set the filename and mimetype, `;type=` and `;filename=` can be used respectively.
-  
+    
     Example: `pfp@ra.jpg;type=image/jpeg;filename=profile.jpg`
-
-  - `@filename`:
-    Use a file as the request body.
-
-  - `header:value`:
-    Add a header, e.g. `user-agent:foobar`
-
-  - `header:`:
-    Unset a header, e.g. `connection:`
-
-  - `header;`:
-    Add a header with an empty value.
-
+    
+  - `@filename`: Use a file as the request body.
+    
+  - `header:value`: Add a header, e.g. `user-agent:foobar`
+    
+  - `header:`: Unset a header, e.g. `connection:`
+    
+  - `header;`: Add a header with an empty value.
+    
   An `@` prefix can be used to read a value from a file. For example: `x-api-key:@api-key.txt`.
   
   A backslash can be used to escape special characters, e.g. `weird\:key=value`.
   
-  To construct a complex JSON object, the `REQUEST_ITEM`'s key can be set to a JSON path instead of a field name. For more information on this syntax, refer to https://httpie.io/docs/cli/nested-json.
+  To construct a complex JSON object, the REQUEST_ITEM's key can be set to a JSON path instead of a field name. For more information on this syntax, refer to https://httpie.io/docs/cli/nested-json.
 
 ## OPTIONS
 
@@ -100,8 +92,8 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   - `colors`: Apply syntax highlighting to output
   - `format`: Pretty-print json and sort headers
   - `none`: Disable both coloring and formatting
-  
-  Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
+    
+  Defaults to `format` if the NO_COLOR env is set and to `none` if stdout is not tty.
 
 - `--format-options=FORMAT_OPTIONS`: Set output formatting options. Supported option are:
   
@@ -110,7 +102,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   - `xml.indent:<NUM>`
   - `xml.format:<true|false>`
   - `headers.sort:<true|false>`
-  
+    
   Example: --format-options=json.indent:2,headers.sort:false.
 
 - `-s`, `--style=THEME`: Output coloring style.
@@ -132,7 +124,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   - `h`: response headers
   - `b`: response body
   - `m`: response metadata
-  
+    
   Example: --print=Hb.
 
 - `-h`, `--headers`: Print only the response headers. Shortcut for --print=h.
@@ -191,7 +183,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `-a`, `--auth=USER[:PASS] | TOKEN`: Authenticate as USER with PASS (-A basic|digest) or with TOKEN (-A bearer).
   
-  PASS will be prompted if missing. Use a trailing colon (i.e. "USER:") to authenticate with just a username.
+  PASS will be prompted if missing. Use a trailing colon (i.e. `USER:`) to authenticate with just a username.
   
   TOKEN is expected if --auth-type=bearer.
 
@@ -211,23 +203,23 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `--timeout=SEC`: Connection timeout of the request.
   
-  The default value is "0", i.e., there is no timeout limit.
+  The default value is `0`, i.e., there is no timeout limit.
 
 - `--proxy=PROTOCOL:URL`: Use a proxy for a protocol. For example: --proxy https:http://proxy.host:8080.
   
-  PROTOCOL can be "all", "http" or "https".
+  PROTOCOL can be `all`, `http` or `https`.
   
   If your proxy requires credentials, put them in the URL, like so: --proxy http:socks5://user:password@proxy.host:8000.
   
   You can specify proxies for multiple protocols by repeating this option.
   
-  The environment variables "ALL_PROXY", "HTTP_PROXY" and "HTTPS_PROXY" can also be used, but are completely ignored if --proxy is passed.
+  The environment variables `ALL_PROXY`, `HTTP_PROXY` and `HTTPS_PROXY` can also be used, but are completely ignored if --proxy is passed.
 
-- `--verify=VERIFY`: If "no", skip SSL verification. If a file path, use it as a CA bundle.
+- `--verify=VERIFY`: If `no`, skip SSL verification. If a file path, use it as a CA bundle.
   
   Specifying a CA bundle will disable the system's built-in root certificates.
   
-  "false" instead of "no" also works. The default is "yes" ("true").
+  `false` instead of `no` also works. The default is `yes` (`true`).
 
 - `--cert=FILE`: Use a client side certificate for SSL.
 
@@ -237,7 +229,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
 
 - `--ssl=VERSION`: Force a particular TLS version.
   
-  "auto" gives the default behavior of negotiating a version with the server.
+  `auto` gives the default behavior of negotiating a version with the server.
 
   [possible values: `auto`, `tls1`, `tls1.1`, `tls1.2`, `tls1.3`]
 
@@ -288,7 +280,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   - `complete-powershell`: Generate completions for powershell
   - `complete-zsh`: Generate completions for zsh
   - `man`: Generate manual page in roff format
-  
+    
   Example: xh --generate=complete-bash > xh.bash.
 
 - `--help`: Print help.

--- a/doc/xh.1.md
+++ b/doc/xh.1.md
@@ -280,6 +280,7 @@ Each `--OPTION` can be reset with a `--no-OPTION` argument.
   - `complete-powershell`: Generate completions for powershell
   - `complete-zsh`: Generate completions for zsh
   - `man`: Generate manual page in roff format
+  - `markdown`: Generate manual page in markdown format
     
   Example: xh --generate=complete-bash > xh.bash.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,7 +109,7 @@ Set output formatting options. Supported option are:
     xml.format:<true|false>
     headers.sort:<true|false>
 
-Example: --format-options=json.indent:2,xml.indent:2,headers.sort:false"
+Example: --format-options=json.indent:2,headers.sort:false"
     )]
     pub format_options: Vec<FormatOptions>,
 
@@ -137,11 +137,11 @@ Example: --format-options=json.indent:2,xml.indent:2,headers.sort:false"
         long_help = "\
 String specifying what the output should contain
 
-    'H' request headers
-    'B' request body
-    'h' response headers
-    'b' response body
-    'm' response metadata
+    H   request headers
+    B   request body
+    h   response headers
+    b   response body
+    m   response metadata
 
 Example: --print=Hb"
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1360,6 +1360,7 @@ pub enum Generate {
     CompletePowershell,
     CompleteZsh,
     Man,
+    Md,
 }
 
 /// HTTPie uses Python's str.decode(). That one's very accepting of different spellings.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -416,7 +416,7 @@ Generate shell completions or man pages. Possible values are:
     complete-powershell   Generate completions for powershell
     complete-zsh          Generate completions for zsh
     man                   Generate manual page in roff format
-    markdown              Generate manual page in markdown format
+    man-markdown          Generate manual page in markdown format
 
 Example: xh --generate=complete-bash > xh.bash",
         conflicts_with = "raw_method_or_url"
@@ -1361,7 +1361,7 @@ pub enum Generate {
     CompletePowershell,
     CompleteZsh,
     Man,
-    Markdown,
+    ManMarkdown,
 }
 
 /// HTTPie uses Python's str.decode(). That one's very accepting of different spellings.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -416,6 +416,7 @@ Generate shell completions or man pages. Possible values are:
     complete-powershell   Generate completions for powershell
     complete-zsh          Generate completions for zsh
     man                   Generate manual page in roff format
+    markdown              Generate manual page in markdown format
 
 Example: xh --generate=complete-bash > xh.bash",
         conflicts_with = "raw_method_or_url"
@@ -1360,7 +1361,7 @@ pub enum Generate {
     CompletePowershell,
     CompleteZsh,
     Man,
-    Md,
+    Markdown,
 }
 
 /// HTTPie uses Python's str.decode(). That one's very accepting of different spellings.

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -114,10 +114,10 @@ fn generate_markdown(app: &mut clap::Command) {
             && opt.get_id() != "pretty"
         {
             let possible_values_text = format!(
-                "\n  [possible values: {}]",
+                "\n  [possible values: {}]\n",
                 possible_values
                     .iter()
-                    .map(|v| v.get_name())
+                    .map(|v| format!("`{}`", v.get_name()))
                     .collect::<Vec<_>>()
                     .join(", ")
             );

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -77,13 +77,15 @@ fn generate_markdown(app: &mut clap::Command) {
             header.push_str(&format!("`--{long}`"));
         }
         if opt.get_action().takes_values() {
+            header.pop();
             let value_name = &opt.get_value_names().unwrap();
             if opt.get_long().is_some() {
                 header.push_str("=");
             } else {
                 header.push_str(" ");
             }
-            header.push_str(&format!("`{}`", value_name.join(" ")));
+            header.push_str(&value_name.join(" "));
+            header.push_str("`")
         }
 
         let mut body = String::new();

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -7,6 +7,7 @@ use crate::cli::Cli;
 use crate::cli::Generate;
 
 const MAN_TEMPLATE: &str = include_str!("../doc/man-template.roff");
+const MD_TEMPLATE: &str = include_str!("../doc/md-template.md");
 
 pub fn generate(bin_name: &str, generate: Generate) {
     let mut app = Cli::into_app();
@@ -49,7 +50,84 @@ complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{
         Generate::Man => {
             generate_manpages(&mut app);
         }
+        Generate::Md => {
+            generate_markdown(&mut app);
+        }
     }
+}
+
+fn generate_markdown(app: &mut clap::Command) {
+    let items: Vec<_> = app.get_arguments().filter(|i| !i.is_hide_set()).collect();
+
+    let mut options = String::new();
+    let non_pos_items = items
+        .iter()
+        .filter(|a| !a.is_positional())
+        .collect::<Vec<_>>();
+
+    for opt in non_pos_items {
+        let mut header = String::new();
+        if let Some(short) = opt.get_short() {
+            header.push_str(&format!("`-{short}`"));
+        }
+        if let Some(long) = opt.get_long() {
+            if !header.is_empty() {
+                header.push_str(", ");
+            }
+            header.push_str(&format!("`--{long}`"));
+        }
+        if opt.get_action().takes_values() {
+            let value_name = &opt.get_value_names().unwrap();
+            if opt.get_long().is_some() {
+                header.push_str("=");
+            } else {
+                header.push_str(" ");
+            }
+            header.push_str(&format!("`{}`", value_name.join(" ")));
+        }
+
+        let mut body = String::new();
+
+        let mut help = opt
+            .get_long_help()
+            .or_else(|| opt.get_help())
+            .expect("option is missing help")
+            .to_string()
+            .replace("\n    ", "\n- ")
+            .replace('\n', "\n    ");
+        if !help.ends_with('.') {
+            help.push('.')
+        }
+
+        body.push_str(&help);
+
+        let possible_values = opt.get_possible_values();
+        if !possible_values.is_empty()
+            && !opt.is_hide_possible_values_set()
+            && opt.get_id() != "pretty"
+        {
+            let possible_values_text = format!(
+                "\n\n    [possible values: {}]",
+                possible_values
+                    .iter()
+                    .map(|v| v.get_name())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            body.push_str(&possible_values_text);
+        }
+        options.push_str("- ");
+        options.push_str(&header);
+        options.push_str(": ");
+        options.push_str(&body);
+        options.push_str("\n\n")
+    }
+
+    let mut manpage = MD_TEMPLATE.to_string();
+
+    manpage = manpage.replace("{{options}}", options.trim());
+
+    print!("{manpage}");
 }
 
 fn generate_manpages(app: &mut clap::Command) {

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -92,14 +92,21 @@ fn generate_markdown(app: &mut clap::Command) {
             .get_long_help()
             .or_else(|| opt.get_help())
             .expect("option is missing help")
-            .to_string()
-            .replace("\n    ", "\n- ")
-            .replace('\n', "\n    ");
+            .to_string();
         if !help.ends_with('.') {
             help.push('.')
         }
 
-        body.push_str(&help);
+        for line in parse_help(&help) {
+            match line {
+                ParsedHelp::Definition(term, Some(description)) => {
+                    body.push_str(&format!("  - `{term}`: {description}"))
+                }
+                ParsedHelp::Definition(term, None) => body.push_str(&format!("  - `{term}`")),
+                ParsedHelp::Line(line) => body.push_str(&format!("  {line}")),
+            }
+            body.push_str("\n")
+        }
 
         let possible_values = opt.get_possible_values();
         if !possible_values.is_empty()
@@ -107,7 +114,7 @@ fn generate_markdown(app: &mut clap::Command) {
             && opt.get_id() != "pretty"
         {
             let possible_values_text = format!(
-                "\n\n    [possible values: {}]",
+                "\n  [possible values: {}]",
                 possible_values
                     .iter()
                     .map(|v| v.get_name())
@@ -119,8 +126,8 @@ fn generate_markdown(app: &mut clap::Command) {
         options.push_str("- ");
         options.push_str(&header);
         options.push_str(": ");
-        options.push_str(&body);
-        options.push_str("\n\n")
+        options.push_str(body.trim_start());
+        options.push_str("\n")
     }
 
     let mut manpage = MD_TEMPLATE.to_string();
@@ -213,7 +220,10 @@ fn generate_manpages(app: &mut clap::Command) {
         .collect::<Vec<_>>();
 
     for opt in non_pos_items {
+        options_roff.control("TP", ["4"]);
+
         let mut header = vec![];
+
         if let Some(short) = opt.get_short() {
             header.push(bold(format!("-{short}")));
         }
@@ -241,6 +251,8 @@ fn generate_manpages(app: &mut clap::Command) {
                 header.push(italic(value_name.join(" ")));
             }
         }
+        options_roff.text(header);
+
         let mut body = vec![];
 
         let mut help = opt
@@ -251,7 +263,43 @@ fn generate_manpages(app: &mut clap::Command) {
         if !help.ends_with('.') {
             help.push('.')
         }
-        body.push(roman(help));
+
+        let mut rs = false;
+        let mut pp = false;
+        for line in parse_help(&help) {
+            match line {
+                ParsedHelp::Definition(term, Some(description)) => {
+                    if !rs {
+                        rs = true;
+                        options_roff.control("RS", ["8"]);
+                    }
+                    options_roff.control("TP", ["8"]);
+                    options_roff.text([roman(term)]);
+                    options_roff.text([roman(description)]);
+                }
+                ParsedHelp::Definition(term, None) => {
+                    if !rs {
+                        rs = true;
+                        options_roff.control("RS", ["8"]);
+                    }
+                    options_roff.control("PP", []);
+                    options_roff.text([roman(term)]);
+                }
+                ParsedHelp::Line(line) => {
+                    if rs {
+                        rs = false;
+                        options_roff.control("RE", []);
+                        pp = true;
+                        options_roff.control("RS", ["4"]);
+                        options_roff.control("PP", []);
+                    }
+                    options_roff.text([roman(line)]);
+                }
+            }
+        }
+        if pp {
+            options_roff.control("RE", []);
+        }
 
         let possible_values = opt.get_possible_values();
         if !possible_values.is_empty()
@@ -268,8 +316,6 @@ fn generate_manpages(app: &mut clap::Command) {
             );
             body.push(roman(possible_values_text));
         }
-        options_roff.control("TP", ["4"]);
-        options_roff.text(header);
         options_roff.text(body);
     }
 
@@ -291,4 +337,27 @@ fn generate_manpages(app: &mut clap::Command) {
     manpage = manpage.replace("{{options}}", options_roff.to_roff().trim());
 
     print!("{manpage}");
+}
+
+enum ParsedHelp<'a> {
+    Line(&'a str),
+    Definition(&'a str, Option<&'a str>),
+}
+
+fn parse_help(body: &str) -> Vec<ParsedHelp<'_>> {
+    let mut parsed: Vec<ParsedHelp> = Vec::new();
+
+    for line in body.lines() {
+        if line.starts_with("    ") {
+            if let Some((term, description)) = line.trim_start().split_once("   ") {
+                parsed.push(ParsedHelp::Definition(term, Some(description.trim_start())))
+            } else {
+                parsed.push(ParsedHelp::Definition(line.trim_start(), None))
+            }
+        } else {
+            parsed.push(ParsedHelp::Line(line.trim_start()))
+        }
+    }
+
+    parsed
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -50,7 +50,7 @@ complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{
         Generate::Man => {
             generate_manpages(&mut app);
         }
-        Generate::Md => {
+        Generate::Markdown => {
             generate_markdown(&mut app);
         }
     }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -59,6 +59,32 @@ complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{
 fn generate_markdown(app: &mut clap::Command) {
     let items: Vec<_> = app.get_arguments().filter(|i| !i.is_hide_set()).collect();
 
+    let mut request_items = String::new();
+    let request_items_help = items
+        .iter()
+        .find(|opt| opt.get_id() == "raw_rest_args")
+        .expect("request_items not found")
+        .get_long_help()
+        .expect("request_items is missing help")
+        .to_string()
+        .replace("\"", "`");
+
+    let mut indent = false;
+    for line in parse_help(&request_items_help) {
+        match line {
+            ParsedHelp::Definition(term, Some(description)) => {
+                request_items.push_str(&format!("  - `{term}`: {description}\n"))
+            }
+            ParsedHelp::Definition(term, None) => {
+                request_items.push_str(&format!("  - `{term}`\n"))
+            }
+            ParsedHelp::Line(line) if indent => request_items.push_str(&format!("    {line}\n")),
+            ParsedHelp::Line(line) => request_items.push_str(&format!("  {line}\n")),
+            ParsedHelp::Indent => indent = true,
+            ParsedHelp::DeIndent => indent = false,
+        }
+    }
+
     let mut options = String::new();
     let non_pos_items = items
         .iter()
@@ -94,20 +120,24 @@ fn generate_markdown(app: &mut clap::Command) {
             .get_long_help()
             .or_else(|| opt.get_help())
             .expect("option is missing help")
-            .to_string();
+            .to_string()
+            .replace("\"", "`");
         if !help.ends_with('.') {
             help.push('.')
         }
 
+        let mut indent = false;
         for line in parse_help(&help) {
             match line {
                 ParsedHelp::Definition(term, Some(description)) => {
-                    body.push_str(&format!("  - `{term}`: {description}"))
+                    body.push_str(&format!("  - `{term}`: {description}\n"))
                 }
-                ParsedHelp::Definition(term, None) => body.push_str(&format!("  - `{term}`")),
-                ParsedHelp::Line(line) => body.push_str(&format!("  {line}")),
+                ParsedHelp::Definition(term, None) => body.push_str(&format!("  - `{term}`\n")),
+                ParsedHelp::Line(line) if indent => body.push_str(&format!("    {line}\n")),
+                ParsedHelp::Line(line) => body.push_str(&format!("  {line}\n")),
+                ParsedHelp::Indent => indent = true,
+                ParsedHelp::DeIndent => indent = false,
             }
-            body.push_str("\n")
         }
 
         let possible_values = opt.get_possible_values();
@@ -134,6 +164,7 @@ fn generate_markdown(app: &mut clap::Command) {
 
     let mut manpage = MD_TEMPLATE.to_string();
 
+    manpage = manpage.replace("{{request_items}}", request_items.trim());
     manpage = manpage.replace("{{options}}", options.trim());
 
     print!("{manpage}");
@@ -146,74 +177,36 @@ fn generate_manpages(app: &mut clap::Command) {
     let items: Vec<_> = app.get_arguments().filter(|i| !i.is_hide_set()).collect();
 
     let mut request_items_roff = Roff::new();
-    let request_items = items
+    let request_items_help = items
         .iter()
         .find(|opt| opt.get_id() == "raw_rest_args")
-        .unwrap();
-    let request_items_help = request_items
+        .expect("request_items not found")
         .get_long_help()
-        .or_else(|| request_items.get_help())
         .expect("request_items is missing help")
         .to_string();
 
-    // replace the indents in request_item help with proper roff controls
-    // For example:
-    //
-    // ```
-    // normal help normal help
-    // normal help normal help
-    //
-    //   request-item-1
-    //     help help
-    //
-    //   request-item-2
-    //     help help
-    //
-    // normal help normal help
-    // ```
-    //
-    // Should look like this with roff controls
-    //
-    // ```
-    // normal help normal help
-    // normal help normal help
-    // .RS 12
-    // .TP
-    // request-item-1
-    // help help
-    // .TP
-    // request-item-2
-    // help help
-    // .RE
-    //
-    // .RS
-    // normal help normal help
-    // .RE
-    // ```
-    let lines: Vec<&str> = request_items_help.lines().collect();
-    let mut rs = false;
-    for i in 0..lines.len() {
-        if lines[i].is_empty() {
-            let prev = lines[i - 1].chars().take_while(|&x| x == ' ').count();
-            let next = lines[i + 1].chars().take_while(|&x| x == ' ').count();
-            if prev != next && next > 0 {
-                if !rs {
-                    request_items_roff.control("RS", ["8"]);
-                    rs = true;
-                }
+    for line in parse_help(&request_items_help) {
+        match line {
+            ParsedHelp::Definition(term, Some(description)) => {
                 request_items_roff.control("TP", ["4"]);
-            } else if prev != next && next == 0 {
-                request_items_roff.control("RE", []);
-                request_items_roff.text(vec![roman("")]);
-                request_items_roff.control("RS", []);
-            } else {
-                request_items_roff.text(vec![roman(lines[i])]);
+                request_items_roff.text([roman(term)]);
+                request_items_roff.text([roman(description)]);
             }
-        } else {
-            request_items_roff.text(vec![roman(lines[i].trim())]);
+            ParsedHelp::Definition(_, None) => {
+                unreachable!()
+            }
+            ParsedHelp::Line(line) => {
+                request_items_roff.text([roman(line)]);
+            }
+            ParsedHelp::Indent => {
+                request_items_roff.control("RS", ["8"]);
+            }
+            ParsedHelp::DeIndent => {
+                request_items_roff.control("RE", []);
+                request_items_roff.control("IP", []);
+            }
         }
     }
-    request_items_roff.control("RE", []);
 
     let mut options_roff = Roff::new();
     let non_pos_items = items
@@ -266,41 +259,28 @@ fn generate_manpages(app: &mut clap::Command) {
             help.push('.')
         }
 
-        let mut rs = false;
-        let mut pp = false;
         for line in parse_help(&help) {
             match line {
                 ParsedHelp::Definition(term, Some(description)) => {
-                    if !rs {
-                        rs = true;
-                        options_roff.control("RS", ["8"]);
-                    }
                     options_roff.control("TP", ["8"]);
                     options_roff.text([roman(term)]);
                     options_roff.text([roman(description)]);
                 }
                 ParsedHelp::Definition(term, None) => {
-                    if !rs {
-                        rs = true;
-                        options_roff.control("RS", ["8"]);
-                    }
-                    options_roff.control("PP", []);
+                    options_roff.control("IP", ["\"\"", "0"]);
                     options_roff.text([roman(term)]);
                 }
                 ParsedHelp::Line(line) => {
-                    if rs {
-                        rs = false;
-                        options_roff.control("RE", []);
-                        pp = true;
-                        options_roff.control("RS", ["4"]);
-                        options_roff.control("PP", []);
-                    }
                     options_roff.text([roman(line)]);
                 }
+                ParsedHelp::Indent => {
+                    options_roff.control("RS", ["8"]);
+                }
+                ParsedHelp::DeIndent => {
+                    options_roff.control("RE", []);
+                    options_roff.control("IP", []);
+                }
             }
-        }
-        if pp {
-            options_roff.control("RE", []);
         }
 
         let possible_values = opt.get_possible_values();
@@ -341,25 +321,151 @@ fn generate_manpages(app: &mut clap::Command) {
     print!("{manpage}");
 }
 
+#[derive(Debug, PartialEq)]
 enum ParsedHelp<'a> {
     Line(&'a str),
     Definition(&'a str, Option<&'a str>),
+    Indent,
+    DeIndent,
 }
 
 fn parse_help(body: &str) -> Vec<ParsedHelp<'_>> {
     let mut parsed: Vec<ParsedHelp> = Vec::new();
 
+    let mut indent = false;
+
     for line in body.lines() {
-        if line.starts_with("    ") {
-            if let Some((term, description)) = line.trim_start().split_once("   ") {
+        if let Some(line) = line.strip_prefix("    ") {
+            if !indent {
+                parsed.push(ParsedHelp::Indent);
+                indent = true;
+            }
+            if let Some(line) = line.strip_prefix("    ") {
+                if let Some(ParsedHelp::Definition(_, defintion)) = parsed.last_mut() {
+                    defintion.replace(line);
+                } else {
+                    parsed.push(ParsedHelp::Line(line))
+                }
+            } else if let Some((term, description)) = line.split_once("   ") {
                 parsed.push(ParsedHelp::Definition(term, Some(description.trim_start())))
             } else {
-                parsed.push(ParsedHelp::Definition(line.trim_start(), None))
+                parsed.push(ParsedHelp::Definition(line, None))
             }
         } else {
+            if indent && !line.is_empty() {
+                parsed.push(ParsedHelp::DeIndent);
+                indent = false;
+            }
             parsed.push(ParsedHelp::Line(line.trim_start()))
         }
     }
 
+    if indent {
+        parsed.push(ParsedHelp::DeIndent);
+    }
+
     parsed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn parse_help_with_definition() {
+        let parsed = parse_help(indoc! {r#"
+            Controls output processing. Possible values are:
+
+                all      (default) Enable both coloring and formatting
+                colors   Apply syntax highlighting to output
+                format   Pretty-print json and sort headers
+                none     Disable both coloring and formatting
+
+            Defaults to "format" if the NO_COLOR env is set and to "none" if stdout is not tty.
+        "#});
+        assert_eq!(
+            parsed,
+            [
+                ParsedHelp::Line("Controls output processing. Possible values are:"),
+                ParsedHelp::Line(""),
+                ParsedHelp::Indent,
+                ParsedHelp::Definition(
+                    "all",
+                    Some("(default) Enable both coloring and formatting")
+                ),
+                ParsedHelp::Definition("colors", Some("Apply syntax highlighting to output")),
+                ParsedHelp::Definition("format", Some("Pretty-print json and sort headers")),
+                ParsedHelp::Definition("none", Some("Disable both coloring and formatting")),
+                ParsedHelp::Line(""),
+                ParsedHelp::DeIndent,
+                ParsedHelp::Line(
+                    "Defaults to \"format\" if the NO_COLOR env is set and to \"none\" if stdout is not tty."
+                )
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_help_with_list() {
+        let parsed = parse_help(indoc! {"
+            String specifying what the output should contain
+
+                H request headers
+                B request body
+
+            Example: --print=Hb
+        "});
+
+        assert_eq!(
+            parsed,
+            [
+                ParsedHelp::Line("String specifying what the output should contain"),
+                ParsedHelp::Line(""),
+                ParsedHelp::Indent,
+                ParsedHelp::Definition("'H' request headers", None),
+                ParsedHelp::Definition("'B' request body", None),
+                ParsedHelp::Line(""),
+                ParsedHelp::DeIndent,
+                ParsedHelp::Line("Example: --print=Hb"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_help_with_extended_definition() {
+        let parsed = parse_help(indoc! {r#"
+            The separator is used to determine the type:
+
+                key==value
+                    Add a query string to the URL.
+
+                key:=value
+                    Add a field with a literal JSON value to the request body.
+
+                    Example: enabled:=true
+
+            A backslash can be used to escape special characters.
+        "#});
+
+        assert_eq!(
+            parsed,
+            [
+                ParsedHelp::Line("The separator is used to determine the type:"),
+                ParsedHelp::Line(""),
+                ParsedHelp::Indent,
+                ParsedHelp::Definition("key==value", Some("Add a query string to the URL.")),
+                ParsedHelp::Line(""),
+                ParsedHelp::Definition(
+                    "key:=value",
+                    Some("Add a field with a literal JSON value to the request body.")
+                ),
+                ParsedHelp::Line(""),
+                ParsedHelp::Line("Example: enabled:=true"),
+                ParsedHelp::Line(""),
+                ParsedHelp::DeIndent,
+                ParsedHelp::Line("A backslash can be used to escape special characters."),
+            ]
+        );
+    }
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -50,7 +50,7 @@ complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{
         Generate::Man => {
             generate_manpages(&mut app);
         }
-        Generate::Markdown => {
+        Generate::ManMarkdown => {
             generate_markdown(&mut app);
         }
     }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -155,16 +155,12 @@ fn generate_markdown(app: &mut clap::Command) {
             );
             body.push_str(&possible_values_text);
         }
-        options.push_str("- ");
-        options.push_str(&header);
-        options.push_str(": ");
-        options.push_str(body.trim_start());
-        options.push_str("\n")
+        options.push_str(&format!("- {header}: {}\n", body.trim_start()));
     }
 
     let mut manpage = MD_TEMPLATE.to_string();
 
-    manpage = manpage.replace("{{request_items}}", request_items.trim());
+    manpage = manpage.replace("{{request_items}}", request_items.trim_end());
     manpage = manpage.replace("{{options}}", options.trim());
 
     print!("{manpage}");

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -106,12 +106,12 @@ fn generate_markdown(app: &mut clap::Command) {
             header.pop();
             let value_name = &opt.get_value_names().unwrap();
             if opt.get_long().is_some() {
-                header.push_str("=");
+                header.push('=');
             } else {
-                header.push_str(" ");
+                header.push(' ');
             }
             header.push_str(&value_name.join(" "));
-            header.push_str("`")
+            header.push('`')
         }
 
         let mut body = String::new();
@@ -407,8 +407,8 @@ mod tests {
         let parsed = parse_help(indoc! {"
             String specifying what the output should contain
 
-                H request headers
-                B request body
+                'H' request headers
+                'B' request body
 
             Example: --print=Hb
         "});

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -337,8 +337,8 @@ fn parse_help(body: &str) -> Vec<ParsedHelp<'_>> {
                 indent = true;
             }
             if let Some(line) = line.strip_prefix("    ") {
-                if let Some(ParsedHelp::Definition(_, defintion)) = parsed.last_mut() {
-                    defintion.replace(line);
+                if let Some(ParsedHelp::Definition(_, description)) = parsed.last_mut() {
+                    description.replace(line);
                 } else {
                     parsed.push(ParsedHelp::Line(line))
                 }


### PR DESCRIPTION
Since github doesn't support rendering roff files, we will use `--generate markdown` to generate `xh.1.md` which is then linked to from `README.md`. The markdown format is inspired by https://github.com/rtomayko/ronn/blob/master/man/ronn.1.ronn

I have also updated `--generate man` to output definitions using roff controls. This should improve how they are rendered in online man pages like https://man.archlinux.org/man/extra/xh/xh.1.en (See `--pretty`, `--generate`, etc)

Resolves #446