### PR TITLE
Fix --auth ignoring credentials with an empty username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Bug fixes
+- Fix `--auth` ignoring credentials when the username is empty (e.g. `-a :password`), see #467 (@upuddu)
+
 ## [0.26.1] - 2026-06-19
 ### Features
 - Pretty-print XML responses, see #450 (@o1x3)

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -48,7 +48,7 @@ impl Auth {
 pub fn parse_auth(auth: &str, host: &str) -> io::Result<(String, Option<String>)> {
     if let Some(cap) = Regex::new(r"^([^:]*):$").unwrap().captures(auth) {
         Ok((cap[1].to_string(), None))
-    } else if let Some(cap) = Regex::new(r"^(.+?):(.+)$").unwrap().captures(auth) {
+    } else if let Some(cap) = Regex::new(r"^(.*?):(.+)$").unwrap().captures(auth) {
         let username = cap[1].to_string();
         let password = cap[2].to_string();
         Ok((username, Some(password)))
@@ -108,6 +108,8 @@ mod tests {
             ("user:password", ("user", Some("password"))),
             ("user:pass:with:colons", ("user", Some("pass:with:colons"))),
             (":", ("", None)),
+            (":password", ("", Some("password"))),
+            (":pass:with:colons", ("", Some("pass:with:colons"))),
         ];
         for (input, output) in expected {
             let (user, pass) = parse_auth(input, "").unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -732,6 +732,20 @@ fn user_auth() {
 }
 
 #[test]
+fn empty_user_password_auth() {
+    let server = server::http(|req| async move {
+        // base64 of ":pass"
+        assert_eq!(req.headers()["Authorization"], "Basic OnBhc3M=");
+        hyper::Response::default()
+    });
+
+    get_command()
+        .args(["--auth=:pass", &server.base_url()])
+        .assert()
+        .success();
+}
+
+#[test]
 fn bearer_auth() {
     let server = server::http(|req| async move {
         assert_eq!(req.headers()["Authorization"], "Bearer SomeToken");


### PR DESCRIPTION
`xh -a :password` (an empty username with a password) currently prompts for a password instead of using the credentials, unlike HTTPie which sends `Authorization: Basic OnBhc3M=`. The credential regex required at least one username character (`.+?`); this loosens it to `.*?` so an empty username before the colon is accepted, leaving the existing `user:`, `:`, and colons-in-password cases unchanged.
