### PR TITLE
Don't let a system proxy leak into the test suite

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -90,6 +90,9 @@ fn get_base_command() -> Command {
     cmd.env("HOME", "");
     cmd.env("NETRC", "");
     cmd.env("XH_CONFIG_DIR", "");
+    // Tests talk to a local server, so never route through a proxy. A system
+    // proxy is picked up even when no proxy env vars are set.
+    cmd.env("NO_PROXY", "127.0.0.1,localhost,example.com");
     #[cfg(target_os = "windows")]
     cmd.env("XH_TEST_MODE_WIN_HOME_DIR", "");
     cmd.env("RUST_BACKTRACE", "0");


### PR DESCRIPTION
`get_base_command` already clears `HOME`, `NETRC` and `XH_CONFIG_DIR`, but a system proxy still gets through — reqwest reads it from the OS even with no proxy env vars set. On such a machine `override_dns_resolution` goes to the proxy instead of the local server and comes back 502, blocking ~143s first, so the suite takes 159s instead of 5.6s.

The value has to be an explicit host list: `NO_PROXY=*` takes reqwest down a different path that adds `Connection: close` and reorders response headers, breaking 8 other tests.
