### PR TITLE
Add target for x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,8 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
           - os: macos-15-intel
             target: x86_64-apple-darwin
             flags: --features=native-tls


### PR DESCRIPTION
Discovered the release is missing a glibc binary when aqua started throwing errors for me. This PR updates the github actions to automatically build glibc binaries for new releases.