### PR TITLE
Fix URL requirement in Nushell completions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -437,7 +437,7 @@ Example: xh --generate=complete-bash > xh.bash",
     ///
     /// A leading colon works as shorthand for localhost. ":8000" is equivalent
     /// to "localhost:8000", and ":/path" is equivalent to "localhost/path".
-    #[clap(value_name = "[METHOD] URL", required = true)]
+    #[clap(value_name = "[METHOD] URL", required_unless_present = "generate")]
     raw_method_or_url: Option<String>,
 
     /// Optional key-value pairs to be included in the request.

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -369,6 +369,21 @@ mod tests {
     use indoc::indoc;
 
     #[test]
+    fn nushell_completion_allows_generate_without_url() {
+        let mut app = Cli::into_app();
+        let mut output = Vec::new();
+        clap_complete::generate(Nushell, &mut app, "xh", &mut output);
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(
+            output
+                .lines()
+                .any(|line| line.trim_start().starts_with("raw_method_or_url?: string")),
+            "generated completion should make raw_method_or_url optional"
+        );
+    }
+
+    #[test]
     fn parse_help_with_definition() {
         let parsed = parse_help(indoc! {r#"
             Controls output processing. Possible values are:


### PR DESCRIPTION
## Summary

- model the request URL as required unless `--generate` is present
- add regression coverage for the optional positional in generated Nushell completions

## Root cause

The URL positional was marked unconditionally required even though it conflicts with the URL-less `--generate` mode. `clap_complete_nushell` copied that unconditional requirement into the generated `export extern`, so Nushell rejected commands such as `xh --generate man` before xh could run.

Using Clap's `required_unless_present = "generate"` keeps the real CLI requirement while allowing the completion generator to emit `raw_method_or_url?: string`.

## Verification

- regression test fails on the unfixed source and passes with this change
- `cargo fmt -- --check`
- `cargo test --target aarch64-apple-darwin --features=native-tls` (82 unit, 203 integration; 2 pre-existing ignored)
- `cargo clippy --tests -- -D warnings -A unknown-lints`
- `RUSTFLAGS="--cfg reqwest_unstable" cargo clippy --all-features --tests -- -D warnings -A unknown-lints`
- `cargo clippy --no-default-features --features=native-tls,online-tests --tests -- -D warnings -A unknown-lints`
- Nushell 0.114.1 end-to-end: source the generated module and run `xh --generate man`

Closes #473
