### PR TITLE
Create session files with owner-only (0600) permissions

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -348,7 +348,7 @@ impl Session {
             if let Some(parent_path) = self.path.parent() {
                 fs::create_dir_all(parent_path)?;
             }
-            let mut session_file = fs::File::create(&self.path)?;
+            let mut session_file = create_session_file(&self.path)?;
             log::debug!("Persisting session to {:?}", self.path);
             let formatter = serde_json::ser::PrettyFormatter::with_indent(b"    ");
             let mut ser = serde_json::Serializer::with_formatter(&mut session_file, formatter);
@@ -357,6 +357,32 @@ impl Session {
         }
         Ok(())
     }
+}
+
+/// Create (or truncate) the session file with permissions restricted to
+/// the owner, since session files can contain credentials (Authorization
+/// headers, cookies). Relying on the umask alone leaves the file
+/// group- or world-readable under common umask settings.
+#[cfg(unix)]
+fn create_session_file(path: &std::path::Path) -> Result<fs::File> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    // `mode` above only applies when the file is newly created; a
+    // pre-existing session file (e.g. from an older xh version, before
+    // this permission was enforced) needs its permissions corrected
+    // explicitly.
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn create_session_file(path: &std::path::Path) -> Result<fs::File> {
+    Ok(fs::File::create(path)?)
 }
 
 fn xh_version() -> String {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2213,6 +2213,103 @@ fn named_sessions() {
     );
 }
 
+/// Regression test: session files can contain credentials (Authorization
+/// headers, cookies), so they must not be created with permissions wider
+/// than owner-only, regardless of the process's umask.
+#[cfg(unix)]
+#[test]
+fn session_files_are_created_with_owner_only_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let server = server::http(|_req| async move {
+        hyper::Response::builder().body("".into()).unwrap()
+    });
+
+    let config_dir = tempdir().unwrap();
+    let random_name = random_string();
+
+    get_command()
+        .env("XH_CONFIG_DIR", config_dir.path())
+        .arg(server.base_url())
+        .arg(format!("--session={random_name}"))
+        .arg("--bearer=hello")
+        .assert()
+        .success();
+
+    let path_to_session = config_dir.path().join::<std::path::PathBuf>(
+        [
+            "sessions",
+            &format!("127.0.0.1_{}", server.port()),
+            &format!("{random_name}.json"),
+        ]
+        .iter()
+        .collect(),
+    );
+
+    let mode = fs::metadata(&path_to_session).unwrap().permissions().mode();
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "session file must be owner-only, got mode {:o}",
+        mode & 0o777
+    );
+}
+
+/// Regression test: a session file created by an older xh version (before
+/// owner-only permissions were enforced) must have its permissions
+/// corrected the next time it's written to, not just left as-is.
+#[cfg(unix)]
+#[test]
+fn preexisting_session_file_permissions_are_corrected() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let server = server::http(|_req| async move {
+        hyper::Response::builder().body("".into()).unwrap()
+    });
+
+    let config_dir = tempdir().unwrap();
+    let random_name = random_string();
+
+    let path_to_session = config_dir.path().join::<std::path::PathBuf>(
+        [
+            "sessions",
+            &format!("127.0.0.1_{}", server.port()),
+            &format!("{random_name}.json"),
+        ]
+        .iter()
+        .collect(),
+    );
+    fs::create_dir_all(path_to_session.parent().unwrap()).unwrap();
+    fs::write(
+        &path_to_session,
+        serde_json::json!({
+            "__meta__": { "about": "xh session file", "xh": "0.0.0" },
+            "auth": { "type": null, "raw_auth": null },
+            "cookies": [],
+            "headers": []
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::set_permissions(&path_to_session, fs::Permissions::from_mode(0o664)).unwrap();
+
+    get_command()
+        .env("XH_CONFIG_DIR", config_dir.path())
+        .arg(server.base_url())
+        .arg(format!("--session={random_name}"))
+        .arg("--bearer=hello")
+        .assert()
+        .success();
+
+    let mode = fs::metadata(&path_to_session).unwrap().permissions().mode();
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "pre-existing session file's permissions must be corrected, got mode {:o}",
+        mode & 0o777
+    );
+}
+
 #[test]
 fn anonymous_sessions() {
     let server = server::http(|_req| async move {


### PR DESCRIPTION
Fixes #476.

## Summary

Session files (`--session=<name>`) can contain credentials (Authorization
headers, cookies), but `Session::persist` (src/session.rs) created them
with plain `fs::File::create`, leaving the resulting permission mode
governed entirely by the process's umask. Under common umask settings
(`0002`, `0022`), the file ends up group- and/or world-readable, so any
other local account on a shared or multi-tenant system can read another
user's stored credentials directly off disk.

## Fix

Adds `create_session_file`, which on Unix opens the file with mode `0600`
via `OpenOptionsExt::mode`, and also explicitly corrects the permissions
of a pre-existing file via `set_permissions` right after opening. This
second step matters because `mode()` only applies when the file is newly
created: a session file written by an older xh version, before this fix,
would otherwise keep its old, wider permissions forever, even after being
rewritten. Non-Unix platforms are unaffected and keep using
`fs::File::create`, since Windows ACLs work differently and aren't
subject to the same umask-driven exposure.

## Testing

- `cargo test --release` passes in full (202 passed, 1 ignored,
  pre-existing and unrelated to this change).
- Added two regression tests:
  - `session_files_are_created_with_owner_only_permissions`: creates a
    session and asserts the resulting file's mode is `0600`.
  - `preexisting_session_file_permissions_are_corrected`: pre-creates a
    session file with mode `0664` (simulating one written by an older xh
    version), runs a request against it, and asserts the mode is
    corrected to `0600`.
- Manually reproduced the issue against an unpatched build: ran `xh
  --session=test <url> "Authorization:Bearer <token>"` under a common
  umask (`0002`, not specially weakened), and confirmed the resulting
  session file had mode `0664` and contained the token in plaintext.
  Repeated against this branch and confirmed the file is `0600`, and
  separately confirmed a pre-existing `0664` session file gets corrected
  to `0600` on the next write.
