### PR TITLE
Add --no-buffer for immediate streaming output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,6 +196,13 @@ Example: --print=Hb"
     #[clap(short = 'S', long = "stream", name = "stream")]
     pub stream_raw: bool,
 
+    /// Buffer streaming output until a complete line is available.
+    ///
+    /// Enabled by default for terminal output. Use --no-buffer to flush each
+    /// response chunk immediately, which is useful for SSE and streaming SSR.
+    #[clap(long = "buffer", name = "buffer")]
+    pub buffer_raw: bool,
+
     ///  Content compressed (encoded) with Deflate algorithm.
     ///
     ///  The Content-Encoding header is set to deflate.
@@ -209,6 +216,9 @@ Example: --print=Hb"
 
     #[clap(skip)]
     pub stream: Option<bool>,
+
+    #[clap(skip)]
+    pub buffer: Option<bool>,
 
     /// Save output to FILE instead of stdout.
     #[clap(short = 'o', long, value_name = "FILE")]
@@ -624,6 +634,12 @@ impl Cli {
             (false, false) => None,
         };
         self.stream = match (self.stream_raw, matches.get_flag("no-stream")) {
+            (true, true) => unreachable!(),
+            (true, false) => Some(true),
+            (false, true) => Some(false),
+            (false, false) => None,
+        };
+        self.buffer = match (self.buffer_raw, matches.get_flag("no-buffer")) {
             (true, true) => unreachable!(),
             (true, false) => Some(true),
             (false, true) => Some(false),
@@ -1787,6 +1803,24 @@ mod tests {
 
         let cli = parse(["--no-stream", "--stream", ":"]).unwrap();
         assert_eq!(cli.stream, Some(true));
+    }
+
+    #[test]
+    fn negating_buffer() {
+        let cli = parse([":"]).unwrap();
+        assert_eq!(cli.buffer, None);
+
+        let cli = parse(["--buffer", ":"]).unwrap();
+        assert_eq!(cli.buffer, Some(true));
+
+        let cli = parse(["--no-buffer", ":"]).unwrap();
+        assert_eq!(cli.buffer, Some(false));
+
+        let cli = parse(["--buffer", "--no-buffer", ":"]).unwrap();
+        assert_eq!(cli.buffer, Some(false));
+
+        let cli = parse(["--no-buffer", "--buffer", ":"]).unwrap();
+        assert_eq!(cli.buffer, Some(true));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -657,7 +657,14 @@ fn run(args: Cli) -> Result<ExitCode> {
         .format_options
         .iter()
         .fold(FormatOptions::default(), FormatOptions::merge);
-    let mut printer = Printer::new(pretty, theme, args.stream, buffer, format_options);
+    let mut printer = Printer::new(
+        pretty,
+        theme,
+        args.stream,
+        args.buffer,
+        buffer,
+        format_options,
+    );
 
     let response_charset = args.response_charset;
     let response_mime = args.response_mime.as_deref();

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -44,6 +44,24 @@ struct BinaryGuard<'a, T: Read> {
     checked: bool,
 }
 
+fn copy_stream(
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+    line_buffered: bool,
+    check_binary: bool,
+) -> io::Result<()> {
+    if !line_buffered {
+        return copy_largebuf(reader, writer, true);
+    }
+
+    let mut guard = BinaryGuard::new(reader, check_binary);
+    while let Some(lines) = guard.read_lines()? {
+        writer.write_all(lines)?;
+        writer.flush()?;
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct FoundBinaryData;
 
@@ -125,6 +143,7 @@ pub struct Printer {
     color: bool,
     theme: Theme,
     stream: Option<bool>,
+    buffer_stream: Option<bool>,
     buffer: Buffer,
 }
 
@@ -133,6 +152,7 @@ impl Printer {
         pretty: Pretty,
         theme: Theme,
         stream: impl Into<Option<bool>>,
+        buffer_stream: impl Into<Option<bool>>,
         buffer: Buffer,
         format_options: FormatOptions,
     ) -> Self {
@@ -144,6 +164,7 @@ impl Printer {
             sort_headers: format_options.headers_sort.unwrap_or(pretty.format()),
             color: pretty.color(),
             stream: stream.into(),
+            buffer_stream: buffer_stream.into(),
             theme,
             buffer,
         }
@@ -246,15 +267,9 @@ impl Printer {
     }
 
     fn print_stream(&mut self, reader: &mut impl Read) -> io::Result<()> {
-        if !self.buffer.is_terminal() {
-            return copy_largebuf(reader, &mut self.buffer, true);
-        }
-        let mut guard = BinaryGuard::new(reader, true);
-        while let Some(lines) = guard.read_lines()? {
-            self.buffer.write_all(lines)?;
-            self.buffer.flush()?;
-        }
-        Ok(())
+        let is_terminal = self.buffer.is_terminal();
+        let line_buffered = is_terminal && self.buffer_stream != Some(false);
+        copy_stream(reader, &mut self.buffer, line_buffered, is_terminal)
     }
 
     fn print_colorized_stream(
@@ -333,6 +348,9 @@ impl Printer {
         content_type: ContentType,
         body: &mut impl Read,
     ) -> io::Result<()> {
+        if self.buffer_stream == Some(false) {
+            return self.print_stream(body);
+        }
         match content_type {
             ContentType::Json => self.print_json_stream(body),
             ContentType::Xml => self.print_syntax_stream(body, "xml"),
@@ -758,7 +776,14 @@ mod tests {
         let theme = args.style.unwrap_or_default();
         let buffer = Buffer::new(args.download, args.output.as_deref(), is_stdout_tty).unwrap();
         let pretty = args.pretty.unwrap_or_else(|| buffer.guess_pretty());
-        Printer::new(pretty, theme, false, buffer, FormatOptions::default())
+        Printer::new(
+            pretty,
+            theme,
+            false,
+            args.buffer,
+            buffer,
+            FormatOptions::default(),
+        )
     }
 
     fn temp_path() -> String {
@@ -766,6 +791,36 @@ mod tests {
         let filename = random_string();
         dir.push(filename);
         dir.to_str().unwrap().to_owned()
+    }
+
+    struct PartialThenError(bool);
+
+    impl Read for PartialThenError {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.0 {
+                Err(io::Error::other("stream paused"))
+            } else {
+                self.0 = true;
+                let chunk = b"incomplete event";
+                buf[..chunk.len()].copy_from_slice(chunk);
+                Ok(chunk.len())
+            }
+        }
+    }
+
+    #[test]
+    fn no_buffer_writes_incomplete_stream_chunks() {
+        let mut output = Vec::new();
+        let error =
+            copy_stream(&mut PartialThenError(false), &mut output, false, false).unwrap_err();
+        assert_eq!(error.to_string(), "stream paused");
+        assert_eq!(output, b"incomplete event");
+
+        let mut output = Vec::new();
+        let error =
+            copy_stream(&mut PartialThenError(false), &mut output, true, false).unwrap_err();
+        assert_eq!(error.to_string(), "stream paused");
+        assert!(output.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a `--no-buffer` option for streaming responses
- preserve the existing terminal line buffering and piped-output behavior by default
- flush incomplete response chunks immediately in unbuffered mode so SSE and streaming SSR output is visible without waiting for a newline

The terminal streaming path currently goes through `BinaryGuard::read_lines`, so bytes are held until a complete line arrives. Unbuffered mode uses the raw chunk-copy path instead and bypasses line-oriented pretty printing, while the existing behavior remains unchanged unless `--no-buffer` is passed.

Closes #273.

## Testing

- `cargo test no_buffer_writes_incomplete_stream_chunks`
- `cargo test negating_buffer`
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
