### PR TITLE
fix: only set a JSON Content-Type when there is a body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Bug fixes
+- Don't set a JSON `Content-Type` for `--json` requests without a body, see #218
+
 ## [0.26.2] - 2026-07-26
 ### Bug fixes
 - Fix `--auth` ignoring credentials when the username is empty (e.g. `-a :password`), see #467 (@upuddu)

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,9 +464,8 @@ fn run(args: Cli) -> Result<ExitCode> {
                         .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
                         .json(&body)
                 } else if args.json {
-                    request_builder
-                        .header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
-                        .header(CONTENT_TYPE, HeaderValue::from_static(JSON_CONTENT_TYPE))
+                    // Don't set Content-Type: there's no JSON body to describe
+                    request_builder.header(ACCEPT, HeaderValue::from_static(JSON_ACCEPT))
                 } else {
                     // We're here because this is the default request type
                     // There's nothing to do

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -444,7 +444,7 @@ pub fn translate(args: Cli) -> Result<Command> {
                 cmd.arg(json_string);
             }
             Body::Json(..) if args.json => {
-                cmd.header("content-type", JSON_CONTENT_TYPE);
+                // Don't set Content-Type: there's no JSON body to describe
                 cmd.header("accept", JSON_ACCEPT);
             }
             Body::Json(..) => {}
@@ -529,7 +529,7 @@ mod tests {
             ),
             (
                 "xh --json httpbin.org/post",
-                "curl http://httpbin.org/post -H 'content-type: application/json' -H 'accept: application/json, */*;q=0.5'",
+                "curl http://httpbin.org/post -H 'accept: application/json, */*;q=0.5'",
             ),
             (
                 "xh --form httpbin.org/post x@/dev/null",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1435,6 +1435,21 @@ fn forced_json() {
     });
 
     get_command()
+        .args(["--json", &server.base_url(), "key=value"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn forced_json_without_body() {
+    let server = server::http(|req| async move {
+        assert_eq!(req.headers().get("content-type"), None);
+        assert_eq!(req.headers()["accept"], "application/json, */*;q=0.5");
+        assert_eq!(req.body_as_string().await, "");
+        hyper::Response::default()
+    });
+
+    get_command()
         .args(["--json", &server.base_url()])
         .assert()
         .success();


### PR DESCRIPTION
Closes #218.

## The problem

`--json` set `Content-Type: application/json` even when there was no body to describe:

```
$ xh --json GET localhost:8749
Accept: application/json, */*;q=0.5
Content-Type: application/json      <- advertising a JSON body
Content-Length: 0                   <- ...that isn't there
```

## The fix

Set it only when a body exists, which is what you settled on in the thread — *"don't set Content-Type unless there is a JSON body"*, following @blyxxyz's point that httpie went the other way and the current state is inconsistent.

```
                        before              after
--json GET              CT: app/json        (none)
--json POST (no items)  CT: app/json        (none)
--json POST k=value     CT: app/json        CT: app/json
```

`Accept: application/json, */*;q=0.5` is unchanged in every case — the issue is only about Content-Type.

## What I checked

I ran the built binary against a local echo server for every way a body can reach xh, since a missing Content-Type on a request that *does* have a body would be a much worse bug than the one being fixed:

```
k=value  k:=1  default POST  --form  @file  --raw  piped stdin  --multipart
```

All still send Content-Type. It's absent only where the body is genuinely empty. An explicit `Content-Type:` from the user still wins, with or without a body, and doesn't produce a duplicate header.

## `--curl`

`src/to_curl.rs` duplicated the same header logic, so I applied the rule there too — otherwise `xh --curl --json URL` would print a `Content-Type` the real request no longer sends, which is exactly the kind of divergence worth avoiding.

One edge worth naming: with a piped stdin body, `--curl` now omits the content-type while the real request sends it. Those matched by accident before. `to_curl.rs:135` documents that translation assumes `--ignore-stdin`, so this seems consistent with the existing intent, but say the word if you'd rather handle it.

## Tests

Two integration tests in `tests/cli.rs`, following the existing style. Verified load-bearing by stashing the source change:

```
assertion `left == right` failed
  left: Some("application/json")
 right: None
```

```
cargo test:        81 passed (unit), 201 passed (integration)
cargo fmt --check: clean
```

CHANGELOG entry added under `## Unreleased`.
