### PR TITLE
ci: add native Windows ARM64 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,9 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             flags: --features=native-tls
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            flags: --features=native-tls
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             use-cross: true
@@ -80,6 +83,10 @@ jobs:
             target: x86_64-pc-windows-msvc
             flags: --features=native-tls
             rustflags: -C target-feature=+crt-static
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            flags: --features=native-tls
+            rustflags: -C target-feature=+crt-static
     steps:
       - uses: actions/checkout@v4
 
@@ -98,7 +105,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: true
 
       - name: Strip release binary (linux and macOS)
-        if: matrix.job.os != 'windows-latest'
+        if: ${{ !startsWith(matrix.job.os, 'windows-') }}
         run: |
           if [ "${{ matrix.job.binutils }}" != "" ]; then
             sudo apt update
@@ -111,7 +118,7 @@ jobs:
       - name: Package
         shell: bash
         run: |
-          if [ "${{ matrix.job.os }}" = "windows-latest" ]; then
+          if [[ "${{ matrix.job.os }}" == windows-* ]]; then
             bin="target/${{ matrix.job.target }}/release/xh.exe"
           else
             bin="target/${{ matrix.job.target }}/release/xh"
@@ -123,7 +130,7 @@ jobs:
           cp CHANGELOG.md doc/xh.1 "$staging"/doc
           cp completions/* "$staging"/completions
 
-          if [ "${{ matrix.job.os }}" = "windows-latest" ]; then
+          if [[ "${{ matrix.job.os }}" == windows-* ]]; then
             7z a "$staging.zip" $staging
           elif [[ "${{ matrix.job.os }}" =~ "macos" ]]; then
             gtar czvf "$staging.tar.gz" $staging


### PR DESCRIPTION
## Summary

- test aarch64-pc-windows-msvc on the native windows-11-arm runner
- build and package a static Windows ARM64 release artifact
- generalize Windows strip and ZIP conditions for both Windows runner labels

## Validation

The release workflow validated the native Windows ARM64 test, build, packaging, and artifact upload:
https://github.com/meop/xh/actions/runs/31941900842

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the resulting diff and validation results.