### PR TITLE
Add --chunked flag for chunked request transfer encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Features
+- Add `--chunked` for sending the request body with chunked transfer encoding, see #4 (@ChrisJr404)
+
 ## [0.26.2] - 2026-07-26
 ### Bug fixes
 - Fix `--auth` ignoring credentials when the username is empty (e.g. `-a :password`), see #467 (@upuddu)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,6 +207,13 @@ Example: --print=Hb"
     #[clap(short = 'x', long = "compress", name = "compress", action = ArgAction::Count)]
     pub compress: u8,
 
+    /// Send the request body using chunked transfer encoding.
+    ///
+    /// The Transfer-Encoding header is set to chunked and no Content-Length header
+    /// is sent. This has no effect on requests without a body.
+    #[clap(long = "chunked", name = "chunked")]
+    pub chunked: bool,
+
     #[clap(skip)]
     pub stream: Option<bool>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,8 @@ use hyper::header::CONTENT_ENCODING;
 use redirect::RedirectFollower;
 use reqwest::blocking::{Body as ReqwestBody, Client};
 use reqwest::header::{
-    ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_TYPE, COOKIE, HeaderValue, RANGE, USER_AGENT,
+    ACCEPT, ACCEPT_ENCODING, CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HeaderValue, RANGE,
+    TRANSFER_ENCODING, USER_AGENT,
 };
 use reqwest::tls;
 use url::Host;
@@ -47,7 +48,7 @@ use crate::auth::{Auth, DigestAuthMiddleware};
 use crate::buffer::Buffer;
 use crate::cli::{Cli, FormatOptions, HttpVersion, Print, Proxy, Verify};
 use crate::download::{download_file, get_file_size};
-use crate::middleware::ClientWithMiddleware;
+use crate::middleware::{ChunkedTransfer, ClientWithMiddleware};
 use crate::printer::Printer;
 use crate::request_items::{Body, FORM_CONTENT_TYPE, JSON_ACCEPT, JSON_CONTENT_TYPE};
 use crate::session::Session;
@@ -629,6 +630,18 @@ fn run(args: Cli) -> Result<ExitCode> {
             .insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
     }
 
+    // Advertise chunked transfer encoding on the request. The body is actually
+    // rewrapped into an unsized stream by the ChunkedTransfer middleware right
+    // before sending, so that hyper drops the Content-Length header and frames
+    // the body in chunks. Setting the header here means it also shows up in the
+    // printed request (and in --offline mode, where no middleware runs); dropping
+    // Content-Length keeps that representation consistent with the wire.
+    if args.chunked && request.body().is_some() {
+        let headers = request.headers_mut();
+        headers.remove(CONTENT_LENGTH);
+        headers.insert(TRANSFER_ENCODING, HeaderValue::from_static("chunked"));
+    }
+
     log::trace!("Built reqwest request");
     // Note: Debug impl is incomplete?
     log::trace!("{request:#?}");
@@ -715,6 +728,11 @@ fn run(args: Cli) -> Result<ExitCode> {
             }
             if let Some(Auth::Digest(username, password)) = &auth {
                 client = client.with(DigestAuthMiddleware::new(username, password));
+            }
+            if args.chunked {
+                // Must be the innermost middleware so the body is streamed on
+                // the actual send, after any upstream buffering/cloning.
+                client = client.with(ChunkedTransfer);
             }
             client.execute(request)?
         };

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,7 +1,8 @@
+use std::io::Cursor;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use reqwest::blocking::{Client, Request, Response};
+use reqwest::blocking::{Body, Client, Request, Response};
 
 #[derive(Clone)]
 pub struct ResponseMeta {
@@ -83,6 +84,27 @@ pub trait Middleware {
         }
 
         Ok(())
+    }
+}
+
+/// Rewraps the request body into a stream of unknown length so that hyper sends
+/// it with `Transfer-Encoding: chunked` instead of a `Content-Length` header.
+///
+/// This is added as the innermost middleware so that every request that actually
+/// reaches the wire (including redirects and digest-auth retries, which buffer
+/// and clone the body upstream) is framed in chunks.
+pub struct ChunkedTransfer;
+
+impl Middleware for ChunkedTransfer {
+    fn handle(&mut self, mut ctx: Context, mut request: Request) -> Result<Response> {
+        let body = match request.body_mut() {
+            Some(body) => Some(body.buffer()?.to_vec()),
+            None => None,
+        };
+        if let Some(body) = body {
+            *request.body_mut() = Some(Body::new(Cursor::new(body)));
+        }
+        self.next(&mut ctx, request)
     }
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -7,7 +7,9 @@ use encoding_rs_io::DecodeReaderBytesBuilder;
 use mime::Mime;
 use reqwest::blocking::{Body, Request, Response};
 use reqwest::cookie::CookieStore;
-use reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HOST, HeaderMap, HeaderValue};
+use reqwest::header::{
+    ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, HOST, HeaderMap, HeaderValue, TRANSFER_ENCODING,
+};
 use url::Url;
 
 use crate::formatting::headers::HeaderFormatter;
@@ -370,10 +372,14 @@ impl Printer {
         // reqwest and hyper add certain headers, but only in the process of
         // sending the request, which we haven't done yet
         if let Some(body) = request.body().and_then(Body::as_bytes) {
-            // Added at https://github.com/seanmonstar/reqwest/blob/c4ebb07343/src/blocking/request.rs#L144
-            headers
-                .entry(CONTENT_LENGTH)
-                .or_insert_with(|| body.len().into());
+            // A chunked body is framed by Transfer-Encoding, so no Content-Length
+            // is sent (and the two are mutually exclusive).
+            if !headers.contains_key(TRANSFER_ENCODING) {
+                // Added at https://github.com/seanmonstar/reqwest/blob/c4ebb07343/src/blocking/request.rs#L144
+                headers
+                    .entry(CONTENT_LENGTH)
+                    .or_insert_with(|| body.len().into());
+            }
         }
         if let Some(host) = request.url().host_str() {
             // FIXME: in case of HTTP/2 we probably don't send this. But we probably

--- a/src/to_curl.rs
+++ b/src/to_curl.rs
@@ -340,6 +340,10 @@ pub fn translate(args: Cli) -> Result<Command> {
         cmd.opt("-H", "--header");
         cmd.arg(format!("{header}:"));
     }
+    if args.chunked {
+        // curl sends the body chunked if you set this header explicitly.
+        cmd.header("Transfer-Encoding", "chunked");
+    }
     if args.ignore_netrc {
         // Already the default, so a bit questionable
         cmd.arg("--no-netrc");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -275,6 +275,95 @@ fn post_empty_body() {
 }
 
 #[test]
+fn chunked_request_body() {
+    let server = server::http(|req| async move {
+        assert_eq!(req.method(), "POST");
+        assert_eq!(
+            req.headers().get(reqwest::header::TRANSFER_ENCODING),
+            Some(&HeaderValue::from_static("chunked"))
+        );
+        assert_eq!(req.headers().get(reqwest::header::CONTENT_LENGTH), None);
+        assert_eq!(req.body_as_string().await, r#"{"foo":"bar"}"#);
+        hyper::Response::default()
+    });
+
+    get_command()
+        .args(["--chunked", "post", &server.base_url(), "foo=bar"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn chunked_has_no_effect_without_a_body() {
+    let server = server::http(|req| async move {
+        assert_eq!(req.method(), "GET");
+        assert_eq!(req.headers().get(reqwest::header::TRANSFER_ENCODING), None);
+        hyper::Response::default()
+    });
+
+    get_command()
+        .args(["--chunked", "get", &server.base_url()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn chunked_request_body_survives_redirect() {
+    let server = server::http(|req| async move {
+        assert_eq!(
+            req.headers().get(reqwest::header::TRANSFER_ENCODING),
+            Some(&HeaderValue::from_static("chunked"))
+        );
+        assert_eq!(req.headers().get(reqwest::header::CONTENT_LENGTH), None);
+        match req.uri().path() {
+            "/first" => {
+                assert_eq!(req.body_as_string().await, r#"{"foo":"bar"}"#);
+                hyper::Response::builder()
+                    .status(307)
+                    .header("Location", "/second")
+                    .body("redirecting...".into())
+                    .unwrap()
+            }
+            "/second" => {
+                assert_eq!(req.body_as_string().await, r#"{"foo":"bar"}"#);
+                hyper::Response::default()
+            }
+            _ => panic!("unknown path"),
+        }
+    });
+
+    get_command()
+        .args([
+            "--chunked",
+            "--follow",
+            "post",
+            &server.url("/first"),
+            "foo=bar",
+        ])
+        .assert()
+        .success();
+    server.assert_hits(2);
+}
+
+#[test]
+fn chunked_shows_transfer_encoding_header_when_offline() {
+    use predicates::boolean::PredicateBooleanExt;
+    get_command()
+        .args(["--offline", "--chunked", ":", "foo=bar"])
+        .assert()
+        .stdout(contains("Transfer-Encoding: chunked"))
+        .stdout(contains("Content-Length").not());
+}
+
+#[test]
+fn chunked_curl_translation() {
+    get_command()
+        .args(["--curl", "--chunked", ":", "foo=bar"])
+        .assert()
+        .stdout(contains("-H 'Transfer-Encoding: chunked'"));
+}
+
+#[test]
 fn nested_json() {
     let server = server::http(|req| async move {
         assert_eq!(


### PR DESCRIPTION
This adds a `--chunked` flag that sends the request body with `Transfer-Encoding: chunked` instead of a `Content-Length` header, one of the remaining items on the HTTPie feature-parity checklist (#4).

The tricky part is that a request body gets buffered in a few places before it's sent (the request printer, the redirect follower's `clone_request`, digest-auth retries), and once a body is buffered its length is known again, so hyper would just fall back to `Content-Length`. To keep things robust I set the `Transfer-Encoding: chunked` header up front (so it also shows up in the printed request and in `--offline` mode) and then, as the *innermost* middleware, rewrap the body into an unsized stream right before it hits the wire. That way every request that actually gets sent — including redirect hops and digest retries — is framed in chunks, regardless of any buffering that happened earlier.

A couple of smaller changes come along with it:
- The request-header printer no longer synthesizes a `Content-Length` line when `Transfer-Encoding` is present, since the two are mutually exclusive and that kept the printed/`--offline` output honest about what goes on the wire.
- `--curl` translation emits `-H 'Transfer-Encoding: chunked'`, which is how you get curl to send a chunked body.

The flag is a no-op on requests without a body.

### Testing
Added integration tests in `tests/cli.rs` covering: a chunked request (asserts `Transfer-Encoding: chunked`, no `Content-Length`, body intact against the mock server), that a chunked body survives a 307 redirect with `--follow`, that `--chunked` has no effect on a bodyless GET, the `--offline` printed headers, and the `--curl` translation. I also manually verified multipart and single-file bodies get sent chunked correctly.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` all pass.
