### PR TITLE
Drop required positionals from Nushell completions

### DIFF
--- a/completions/xh.nu
+++ b/completions/xh.nu
@@ -145,8 +145,6 @@ module completions {
     --no-generate
     --no-help
     --version(-V)             # Print version
-    raw_method_or_url: string # The request URL, preceded by an optional HTTP method
-    ...raw_rest_args: string  # Optional key-value pairs to be included in the request.
   ]
 
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -39,7 +39,24 @@ complete -c {bin_name} -n 'string match -qr "@" -- (commandline -ct)' -kxa "(__{
             stdout.write_all(&buf).unwrap();
         }
         Generate::CompleteNushell => {
-            clap_complete::generate(Nushell, &mut app, bin_name, &mut io::stdout());
+            use std::io::Write;
+            let mut buf = Vec::new();
+            clap_complete::generate(Nushell, &mut app, bin_name, &mut buf);
+            // clap_complete_nushell does not honor Arg::hide and emits these as
+            // required positionals. Nushell then rejects `xh --generate ...` at
+            // parse time, and the clap-internal names should not appear in
+            // completions.
+            let script = String::from_utf8(buf).unwrap();
+            let mut stdout = io::stdout();
+            for line in script.lines() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with("raw_method_or_url")
+                    || trimmed.starts_with("...raw_rest_args")
+                {
+                    continue;
+                }
+                writeln!(stdout, "{line}").unwrap();
+            }
         }
         Generate::CompletePowershell => {
             clap_complete::generate(Shell::PowerShell, &mut app, bin_name, &mut io::stdout());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3886,3 +3886,15 @@ fn reason_phrase_is_preserved() {
 
         "#});
 }
+
+#[test]
+fn nushell_completions_omit_raw_positionals() {
+    get_base_command()
+        .args(["--generate", "complete-nushell"])
+        .assert()
+        .success()
+        .stdout(contains("export extern xh"))
+        .stdout(function(|script: &str| {
+            !script.contains("raw_method_or_url") && !script.contains("raw_rest_args")
+        }));
+}


### PR DESCRIPTION
Sourcing generated `completions/xh.nu` via `use xh.nu *` made Nushell treat `raw_method_or_url` as a required positional, so valid commands like `xh --generate man` failed at parse time with `nu::parser::missing_positional`.

`--generate` already conflicts with that positional in the real CLI, but Nushell still required it when parsing the `export extern`.

Fixes #473

## Changes

- Post-process Nushell completions in `src/generation.rs` so `raw_method_or_url` and `...raw_rest_args` are omitted. `clap_complete_nushell` does not honor `Arg::hide`, and those clap-internal names should not appear in completions.
- Regenerated `completions/xh.nu`.
- Added a regression test that generates `complete-nushell` and asserts the signature does not contain those names.

CLI validation is unchanged. Zsh `_xh` is unchanged (as requested).

## Testing

- `cargo fmt --check`
- `cargo test --features=native-tls` (including `nushell_completions_omit_raw_positionals`)
- `cargo clippy --tests -- -D warnings -A unknown-lints`