### PR TITLE
Detect and error on incomplete downloads

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -164,7 +164,7 @@ const SPINNER_TEMPLATE: &str = "{spinner:.green} {bytes} {bytes_per_sec} {wide_m
 const UNCOLORED_SPINNER_TEMPLATE: &str = "{spinner} {bytes} {bytes_per_sec} {wide_msg}";
 
 pub fn download_file(
-    mut response: Response,
+    response: Response,
     file_name: Option<PathBuf>,
     // If we fall back on taking the filename from the URL it has to be the
     // original URL, before redirects. That's less surprising and matches
@@ -220,7 +220,8 @@ pub fn download_file(
     let starting_time = Instant::now();
 
     let pb = if quiet {
-        None
+        // Still counts the downloaded bytes, it just doesn't display anything.
+        ProgressBar::hidden()
     } else if let Some(total_length) = total_length {
         eprintln!(
             "Downloading {} to {:?}",
@@ -234,7 +235,7 @@ pub fn download_file(
                 UNCOLORED_BAR_TEMPLATE
             })?
             .progress_chars("#>-");
-        Some(ProgressBar::new(total_length).with_style(style))
+        ProgressBar::new(total_length).with_style(style)
     } else {
         eprintln!("Downloading to {dest_name:?}");
         let style = ProgressStyle::default_bar().template(if color {
@@ -242,42 +243,48 @@ pub fn download_file(
         } else {
             UNCOLORED_SPINNER_TEMPLATE
         })?;
-        Some(ProgressBar::new_spinner().with_style(style))
+        ProgressBar::new_spinner().with_style(style)
     };
-    if let Some(pb) = &pb {
-        pb.set_position(starting_length);
-        pb.reset_eta();
+    pb.set_position(starting_length);
+    pb.reset_eta();
+
+    let compression_type = get_compression_type(response.headers());
+    copy_largebuf(
+        &mut decompress(&mut pb.wrap_read(response), compression_type),
+        &mut buffer,
+        false,
+    )?;
+    // The progress bar wraps the response before it's decompressed, so this is
+    // the number of bytes we received, matching the units of `total_length`.
+    let total_downloaded_length = pb.position();
+    let downloaded_length = total_downloaded_length - starting_length;
+    pb.finish_and_clear();
+
+    if !quiet {
+        let time_taken = starting_time.elapsed();
+        if !time_taken.is_zero() {
+            eprintln!(
+                "Done. {} in {:.5}s ({}/s)",
+                HumanBytes(downloaded_length),
+                time_taken.as_secs_f64(),
+                HumanBytes((downloaded_length as f64 / time_taken.as_secs_f64()) as u64)
+            );
+        } else {
+            eprintln!("Done. {}", HumanBytes(downloaded_length));
+        }
     }
 
-    match pb {
-        Some(ref pb) => {
-            let compression_type = get_compression_type(response.headers());
-            copy_largebuf(
-                &mut decompress(&mut pb.wrap_read(response), compression_type),
-                &mut buffer,
-                false,
-            )?;
-            let downloaded_length = pb.position() - starting_length;
-            pb.finish_and_clear();
-            let time_taken = starting_time.elapsed();
-            if !time_taken.is_zero() {
-                eprintln!(
-                    "Done. {} in {:.5}s ({}/s)",
-                    HumanBytes(downloaded_length),
-                    time_taken.as_secs_f64(),
-                    HumanBytes((downloaded_length as f64 / time_taken.as_secs_f64()) as u64)
-                );
-            } else {
-                eprintln!("Done. {}", HumanBytes(downloaded_length));
-            }
-        }
-        None => {
-            let compression_type = get_compression_type(response.headers());
-            copy_largebuf(
-                &mut decompress(&mut response, compression_type),
-                &mut buffer,
-                false,
-            )?;
+    // Only meaningful if the body wasn't compressed: a decoder may stop reading
+    // before the end of the stream (e.g. GzDecoder stops after the first member),
+    // which would leave trailing bytes uncounted. A compressed body that's cut
+    // short fails while decoding instead.
+    if let Some(total_length) = total_length {
+        if compression_type.is_none() && total_downloaded_length != total_length {
+            return Err(anyhow!(
+                "Incomplete download: size={}; downloaded={}",
+                total_length,
+                total_downloaded_length
+            ));
         }
     }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -260,32 +260,41 @@ pub fn download_file(
     let downloaded_length = total_downloaded_length - starting_length;
     pb.finish_and_clear();
 
+    // Only meaningful if the body wasn't compressed: a decoder may stop short of the
+    // end of the stream, and a truncated compressed body fails while decoding anyway.
+    let incomplete = total_length.filter(|&total_length| {
+        compression_type.is_none() && total_downloaded_length != total_length
+    });
+
     if !quiet {
+        let verb = if incomplete.is_some() {
+            "Interrupted"
+        } else {
+            "Done"
+        };
         let time_taken = starting_time.elapsed();
         if !time_taken.is_zero() {
             eprintln!(
-                "Done. {} in {:.5}s ({}/s)",
+                "{verb}. {} in {:.5}s ({}/s)",
                 HumanBytes(downloaded_length),
                 time_taken.as_secs_f64(),
                 HumanBytes((downloaded_length as f64 / time_taken.as_secs_f64()) as u64)
             );
         } else {
-            eprintln!("Done. {}", HumanBytes(downloaded_length));
+            eprintln!("{verb}. {}", HumanBytes(downloaded_length));
+        }
+        if incomplete.is_some() {
+            // Separate the summary from the error message that follows.
+            eprintln!();
         }
     }
 
-    // Only meaningful if the body wasn't compressed: a decoder may stop reading
-    // before the end of the stream (e.g. GzDecoder stops after the first member),
-    // which would leave trailing bytes uncounted. A compressed body that's cut
-    // short fails while decoding instead.
-    if let Some(total_length) = total_length {
-        if compression_type.is_none() && total_downloaded_length != total_length {
-            return Err(anyhow!(
-                "Incomplete download: size={}; downloaded={}",
-                total_length,
-                total_downloaded_length
-            ));
-        }
+    if let Some(total_length) = incomplete {
+        return Err(anyhow!(
+            "Incomplete download: size={}; downloaded={}",
+            total_length,
+            total_downloaded_length
+        ));
     }
 
     Ok(())

--- a/tests/cases/download.rs
+++ b/tests/cases/download.rs
@@ -489,3 +489,98 @@ fn error_code_416_is_not_ignored_when_not_resuming_download() {
 
     assert_eq!(fs::exists(filename).unwrap(), false);
 }
+
+#[test]
+fn it_errors_on_incomplete_download_when_resuming() {
+    let server = server::http(|req| async move {
+        assert_eq!(req.headers()[hyper::header::RANGE], "bytes=5-");
+
+        // Promises 7 more bytes but only sends 4 of them.
+        hyper::Response::builder()
+            .status(206)
+            .header(hyper::header::CONTENT_RANGE, "bytes 5-11/12")
+            .body(" wor".into())
+            .unwrap()
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let filename = dir.path().join("input.txt");
+    OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&filename)
+        .unwrap()
+        .write_all(b"Hello")
+        .unwrap();
+
+    get_command()
+        .arg("--download")
+        .arg("--continue")
+        .arg("--output")
+        .arg(&filename)
+        .arg(server.base_url())
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(contains("Done."))
+        .stderr(contains("Incomplete download: size=12; downloaded=9"));
+
+    assert_eq!(fs::read_to_string(&filename).unwrap(), "Hello wor");
+}
+
+#[test]
+fn it_errors_on_incomplete_download_when_resuming_quietly() {
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .status(206)
+            .header(hyper::header::CONTENT_RANGE, "bytes 5-11/12")
+            .body(" wor".into())
+            .unwrap()
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let filename = dir.path().join("input.txt");
+    OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&filename)
+        .unwrap()
+        .write_all(b"Hello")
+        .unwrap();
+
+    get_command()
+        .arg("--download")
+        .arg("--continue")
+        .arg("--quiet")
+        .arg("--output")
+        .arg(&filename)
+        .arg(server.base_url())
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(contains("Incomplete download: size=12; downloaded=9"));
+}
+
+#[test]
+fn it_does_not_error_on_complete_download() {
+    let server = server::http(|_req| async move {
+        hyper::Response::builder()
+            .body("file contents\n".into())
+            .unwrap()
+    });
+
+    let dir = tempdir().unwrap();
+    let outfile = dir.path().join("outfile");
+    get_command()
+        .arg("--download")
+        .arg("--output")
+        .arg(&outfile)
+        .arg(server.base_url())
+        .assert()
+        .success()
+        .stderr(contains("Done."));
+
+    assert_eq!(fs::read_to_string(&outfile).unwrap(), "file contents\n");
+}

--- a/tests/cases/download.rs
+++ b/tests/cases/download.rs
@@ -490,6 +490,8 @@ fn error_code_416_is_not_ignored_when_not_resuming_download() {
     assert_eq!(fs::exists(filename).unwrap(), false);
 }
 
+// Only the resume path is testable: hyper won't serve a body shorter than its own
+// Content-Length, and the client would reject it before we compare lengths.
 #[test]
 fn it_errors_on_incomplete_download_when_resuming() {
     let server = server::http(|req| async move {
@@ -523,8 +525,10 @@ fn it_errors_on_incomplete_download_when_resuming() {
         .assert()
         .failure()
         .code(1)
-        .stderr(contains("Done."))
-        .stderr(contains("Incomplete download: size=12; downloaded=9"));
+        .stderr(contains("Interrupted."))
+        .stderr(contains(
+            "\n\nxh: error: Incomplete download: size=12; downloaded=9",
+        ));
 
     assert_eq!(fs::read_to_string(&filename).unwrap(), "Hello wor");
 }
@@ -561,26 +565,4 @@ fn it_errors_on_incomplete_download_when_resuming_quietly() {
         .failure()
         .code(1)
         .stderr(contains("Incomplete download: size=12; downloaded=9"));
-}
-
-#[test]
-fn it_does_not_error_on_complete_download() {
-    let server = server::http(|_req| async move {
-        hyper::Response::builder()
-            .body("file contents\n".into())
-            .unwrap()
-    });
-
-    let dir = tempdir().unwrap();
-    let outfile = dir.path().join("outfile");
-    get_command()
-        .arg("--download")
-        .arg("--output")
-        .arg(&outfile)
-        .arg(server.base_url())
-        .assert()
-        .success()
-        .stderr(contains("Done."));
-
-    assert_eq!(fs::read_to_string(&outfile).unwrap(), "file contents\n");
 }


### PR DESCRIPTION
Compare bytes received against the expected total (Content-Length, or the Content-Range total when resuming with --continue) once the copy finishes. On mismatch, print an error and exit 1, matching HTTPie's behavior.

Skips the check for compressed responses, since a server that ignores our Accept-Encoding: identity request and returns a compressed body will have a Content-Length that reflects the wire size, not the decoded size.

Open question: currently a hard error (exit 1) to match HTTPie. Happy to switch to a warning if you'd prefer.

Fixes #254