### PR TITLE
Buffer session file writes

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -348,12 +348,13 @@ impl Session {
             if let Some(parent_path) = self.path.parent() {
                 fs::create_dir_all(parent_path)?;
             }
-            let mut session_file = fs::File::create(&self.path)?;
+            let mut session_file = io::BufWriter::new(fs::File::create(&self.path)?);
             log::debug!("Persisting session to {:?}", self.path);
             let formatter = serde_json::ser::PrettyFormatter::with_indent(b"    ");
             let mut ser = serde_json::Serializer::with_formatter(&mut session_file, formatter);
             self.content.serialize(&mut ser)?;
             session_file.write_all(b"\n")?;
+            session_file.flush()?;
         }
         Ok(())
     }


### PR DESCRIPTION
serde_json's pretty printer writes each JSON token separately, and fs::File does no buffering, so persisting a session issued one write(2) syscall per brace, key, colon, comma and indentation run. The syscall count scaled with the number of cookies and headers rather than the file size: 500,081 writes to save a session with 5,000 of each, against 248 once buffered.

Flush explicitly so write errors are reported rather than swallowed by BufWriter's Drop.

Fixes #488